### PR TITLE
Improve default config file resolution

### DIFF
--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -199,7 +199,7 @@ module Fastlane
       end
 
       def self.default_info_plist_path
-        Dir.glob("./{ios/,}*/Info.plist").reject {|path| path.include?('build/') }.first
+        Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }.first
       end
 
       def self.options_from_info_plist file_path

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -14,14 +14,25 @@ module Fastlane
         else
           payload.merge!(options_from_info_plist(params[:config_file])) if params[:config_file]
         end
+
+        default_plist = default_info_plist_path
+        default_manifest = default_android_manifest_path
+        if (lane_context[:PLATFORM_NAME] == :android and params[:config_file] == default_manifest) or
+           (lane_context[:PLATFORM_NAME] != :android and params[:config_file] == default_plist)
+          # Load custom API key and version properties only if config file has not been overridden
+          payload[:apiKey] = params[:api_key] unless params[:api_key].nil?
+          payload[:appVersion] = params[:app_version] unless params[:app_version].nil?
+          payload[:appVersionCode] = params[:android_version_code] unless params[:android_version_code].nil?
+          payload[:appBundleVersion] = params[:ios_bundle_version] unless params[:ios_bundle_version].nil?
+        else
+          # Print which file is populating version and API key information since the value has been
+          # overridden
+          UI.message("Loading API key and app version info from #{params[:config_file]}")
+        end
         payload.delete(:config_file)
 
         # Overwrite automated options with configured if set
-        payload[:apiKey] = params[:api_key] unless params[:api_key].nil?
-        payload[:appVersion] = params[:app_version] unless params[:app_version].nil?
         payload[:releaseStage] = params[:release_stage] unless params[:release_stage].nil?
-        payload[:appVersionCode] = params[:android_version_code] unless params[:android_version_code].nil?
-        payload[:appBundleVersion] = params[:ios_bundle_version] unless params[:ios_bundle_version].nil?
         payload[:builderName] = params[:builder]
 
         payload[:sourceControl][:revision] = params[:revision] if params[:revision]

--- a/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
+++ b/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 Action = Fastlane::Actions::UploadSymbolsToBugsnagAction
 
-FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
-
 describe Action do
 
   it 'has an executable upload script' do

--- a/tools/fastlane-plugin/spec/fixtures/ios_proj/FirstRealFolder/Info.plist
+++ b/tools/fastlane-plugin/spec/fixtures/ios_proj/FirstRealFolder/Info.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>BugsnagAPIKey</key>
+    <string>other-key</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.0-other</string>
+	<key>CFBundleVersion</key>
+	<string>56</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>
+
+

--- a/tools/fastlane-plugin/spec/fixtures/ios_proj/Project/Info.plist
+++ b/tools/fastlane-plugin/spec/fixtures/ios_proj/Project/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>BugsnagAPIKey</key>
+    <string>project-key</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0-project</string>
+	<key>CFBundleVersion</key>
+	<string>6</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>
+

--- a/tools/fastlane-plugin/spec/fixtures/ios_proj/aaTests/Info.plist
+++ b/tools/fastlane-plugin/spec/fixtures/ios_proj/aaTests/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>BugsnagAPIKey</key>
+    <string>test-key</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>
+

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -4,8 +4,6 @@ require 'fastlane/actions/get_info_plist_value'
 
 BuildAction = Fastlane::Actions::SendBuildToBugsnagAction
 
-FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
-
 describe BuildAction do
   def load_default_opts
     BuildAction.available_options.map do |x|

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+require 'json'
+require 'fastlane/actions/get_info_plist_value'
+
+BuildAction = Fastlane::Actions::SendBuildToBugsnagAction
+
+FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
+
+describe BuildAction do
+  def load_default_opts
+    BuildAction.available_options.map do |x|
+      [x.key, x.default_value]
+    end.to_h
+  end
+
+  context 'building an iOS project' do
+    it 'detects default Info.plist file excluding test dirs' do
+      expect(BuildAction).to receive(:send_notification) do |url, body|
+        payload = ::JSON.load(body)
+        expect(payload['appVersion']).to eq '3.0-other'
+        expect(payload['appBundleVersion']).to eq '56'
+        expect(payload['apiKey']).to eq 'other-key'
+      end
+
+      Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+        BuildAction.run(load_default_opts)
+      end
+    end
+
+    context 'using default config_file option' do
+      context 'override API key option' do
+        it 'reads API key from the api_key option' do
+          expect(BuildAction).to receive(:send_notification) do |url, body|
+            payload = ::JSON.load(body)
+            expect(payload['apiKey']).to eq 'baobab'
+          end
+
+          Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+            BuildAction.run(load_default_opts.merge({
+              api_key: 'baobab'
+            }))
+          end
+        end
+
+        it 'reads version info from the config file' do
+          expect(BuildAction).to receive(:send_notification) do |url, body|
+            payload = ::JSON.load(body)
+            expect(payload['appVersion']).to eq '4.0.0'
+            expect(payload['appBundleVersion']).to eq '400'
+          end
+
+          Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+            BuildAction.run(load_default_opts.merge({
+              app_version: '4.0.0',
+              ios_bundle_version: '400'
+            }))
+          end
+        end
+      end
+    end
+
+    context 'override config_file option' do
+      it 'reads API key and version info from the config file' do
+        expect(BuildAction).to receive(:send_notification) do |url, body|
+          payload = ::JSON.load(body)
+          expect(payload['appVersion']).to eq '2.0-project'
+          expect(payload['appBundleVersion']).to eq '6'
+          expect(payload['apiKey']).to eq 'project-key'
+        end
+
+        Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+          BuildAction.run(load_default_opts.merge({
+            config_file: File.join('Project', 'Info.plist')
+          }))
+        end
+      end
+
+      context 'override API key option' do
+        it 'reads API key from the config file' do
+          expect(BuildAction).to receive(:send_notification) do |url, body|
+            payload = ::JSON.load(body)
+            expect(payload['apiKey']).to eq 'project-key'
+          end
+
+          Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+            BuildAction.run(load_default_opts.merge({
+              config_file: File.join('Project', 'Info.plist'),
+              api_key: 'baobab'
+            }))
+          end
+        end
+
+        it 'reads version info from the config file' do
+          expect(BuildAction).to receive(:send_notification) do |url, body|
+            payload = ::JSON.load(body)
+            expect(payload['appVersion']).to eq '2.0-project'
+            expect(payload['appBundleVersion']).to eq '6'
+          end
+
+          Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+            BuildAction.run(load_default_opts.merge({
+              config_file: File.join('Project', 'Info.plist'),
+              app_version: '4.0.0',
+              ios_bundle_version: '400'
+            }))
+          end
+        end
+      end
+    end
+  end
+end

--- a/tools/fastlane-plugin/spec/spec_helper.rb
+++ b/tools/fastlane-plugin/spec/spec_helper.rb
@@ -6,3 +6,5 @@ end
 
 require 'fastlane' # to import the Action super class
 require 'fastlane/plugin/bugsnag' # import the actual plugin
+
+FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))


### PR DESCRIPTION
* Improves default Info.plist file detection by excluding files in `test` directories
* Changes the way that configuration options are loaded when the `config_file` option is overridden:
  * If `config_file` is changed from the default, it has precedence when loading API key and version info. The file being used is printed when `send_build_to_bugsnag` is run.
  * If `config_file` is nil/equal to a default value, API key and version info is loaded from params (which includes default values)

Fixes #11