### PR TITLE
fix: Convert linked gem files to copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## TBD
+
+The v1.3.3 version of the gem was packaged incorrectly, leading to the fastlane
+plugin being unable to upload dSYMs.
+
 ## 1.3.3 (2018-07-11)
 
 ### Bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@
 * [Make a pull request](https://help.github.com/articles/using-pull-requests)
 * Thanks!
 
+## Running the tests
+
+Install the dependencies with `make bootstrap`, then run the unit and
+integration suites with `make test`
+
 ## Releasing a new version
 
 1. Update the CHANGELOG with new content

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,5 +19,5 @@
 4. Tag the release
 5. Push
    * Create a new GitHub release with the changes
-   * Update the fastlane-plugin-bugsnag gem
+   * Open `tools/fastlane-plugin` and run `rake release`
 6. Update the documentation as needed on docs.bugsnag.com

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,21 @@ $(MANDIR)/man1/$(PROJECT).1: man/$(PROJECT).pod
 	@pod2man --center $(PROJECT) --release $(VERSION) man/$(PROJECT).pod > $@
 	@chmod 444 $@
 
-.PHONY: features
+.PHONY: boostrap uninstall test test_unit test_features
 
 install: $(BINDIR)/$(PROJECT) $(MANDIR)/man1/$(PROJECT).1
 
 uninstall:
 	@rm $(BINDIR)/$(PROJECT) $(MANDIR)/man1/$(PROJECT).1
 
-test:
+bootstrap:
+	@bundle install
+	@cd tools/fastlane-plugin && bundle install
+
+test_unit:
 	@cd tools/fastlane-plugin && bundle exec rake spec
-	@bundle exec maze-runner
+
+test_features:
+	@bundle exec maze-runner -c features/*.feature
+
+test: test_unit test_features

--- a/features/fixtures/fl-project/Gemfile
+++ b/features/fixtures/fl-project/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'fastlane'
-gem 'fastlane-plugin-bugsnag', :path => '../../../tools/fastlane-plugin'
+gem 'fastlane-plugin-bugsnag'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,8 +2,14 @@ Bundler.with_clean_env do
   Dir.chdir 'tools/fastlane-plugin' do
     `rake build`
   end
+end
+
+Bundler.with_clean_env do
   Dir.chdir 'features/fixtures/fl-project' do
-    `bundle install`
+    gem_path = Dir['../../../tools/fastlane-plugin/fastlane-plugin-bugsnag-*.gem'].last
+    `bundle config path vendor`
+    `bundle install --gemfile=Gemfile`
+    `gem install #{gem_path} -i vendor`
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,7 @@
 Bundler.with_clean_env do
+  Dir.chdir 'tools/fastlane-plugin' do
+    `rake build`
+  end
   Dir.chdir 'features/fixtures/fl-project' do
     `bundle install`
   end

--- a/tools/fastlane-plugin/LICENSE.txt
+++ b/tools/fastlane-plugin/LICENSE.txt
@@ -1,1 +1,0 @@
-../../LICENSE.txt

--- a/tools/fastlane-plugin/Rakefile
+++ b/tools/fastlane-plugin/Rakefile
@@ -1,5 +1,3 @@
-require 'bundler/gem_tasks'
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new
 
@@ -7,3 +5,27 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
 task default: [:spec, :rubocop]
+
+desc "Build the gem"
+task :build do
+  # Copy required files into the gem
+  puts "Assembling gem files..."
+  gem_dir = File.dirname(__FILE__)
+  bin_file = File.join(gem_dir, '..', '..', 'bin', 'bugsnag-dsym-upload')
+  license = File.join(gem_dir, '..', '..', 'LICENSE.txt')
+  cp bin_file, gem_dir
+  cp license, gem_dir
+
+  system("gem build fastlane-plugin-bugsnag.gemspec")
+
+  # Clean up
+  puts "Cleaning up temporary files..."
+  rm File.join(gem_dir, 'LICENSE.txt')
+  rm File.join(gem_dir, 'bugsnag-dsym-upload')
+end
+
+desc "Release the latest version to RubyGems"
+task :release => :build do
+  require_relative 'lib/fastlane/plugin/bugsnag/version'
+  system("gem push fastlane-plugin-bugsnag-#{Fastlane::Bugsnag::VERSION}.gem")
+end

--- a/tools/fastlane-plugin/Rakefile
+++ b/tools/fastlane-plugin/Rakefile
@@ -1,10 +1,7 @@
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
-
-require 'rubocop/rake_task'
-RuboCop::RakeTask.new(:rubocop)
-
-task default: [:spec, :rubocop]
+desc "Run the unit tests"
+task :spec do
+  system("rspec")
+end
 
 desc "Build the gem"
 task :build do
@@ -29,3 +26,5 @@ task :release => :build do
   require_relative 'lib/fastlane/plugin/bugsnag/version'
   system("gem push fastlane-plugin-bugsnag-#{Fastlane::Bugsnag::VERSION}.gem")
 end
+
+task default: :spec

--- a/tools/fastlane-plugin/bugsnag-dsym-upload
+++ b/tools/fastlane-plugin/bugsnag-dsym-upload
@@ -1,1 +1,0 @@
-../../bin/bugsnag-dsym-upload

--- a/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
+++ b/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
@@ -4,8 +4,19 @@ Action = Fastlane::Actions::UploadSymbolsToBugsnagAction
 
 describe Action do
 
-  it 'has an executable upload script' do
-    expect(File.exist?(Action::UPLOAD_SCRIPT_PATH)).to be true
+  context "the packaged gem" do
+    gem_name = "fastlane-plugin-bugsnag-#{Fastlane::Bugsnag::VERSION}"
+
+    after do
+      FileUtils.rm_rf(gem_name)
+      FileUtils.rm_rf("#{gem_name}.gem")
+    end
+
+    it 'has an executable upload script' do
+      system('rake build')
+      system("gem unpack #{gem_name}.gem")
+      expect(File.exist?(File.join("#{gem_name}/bugsnag-dsym-upload"))).to be true
+    end
   end
 
   describe '#run' do


### PR DESCRIPTION
## Goal

At some point, linked gem files started being copied directly instead of
becoming actual files in gems. This fixes the packaging and process for
generating the gem to ensure that the resulting binary can run.

## Changeset

### Added

* New `build` and `release` commands in the Rakefile to ensure that included files are up to date
* New release instructions in CONTRIBUTING.md

## Tests

* Tested by building and installing the gem locally with RubyGems 2.7.7
* Updated integration tests to use a prebuilt artifact and catch these kinds of issues in CI

### Linked issues

Fixes #21

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Idiomatic use of the language
