### PR TITLE
Pin the HTTP version used by dSYM upload to 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.2 (TBD)
+
+### Bug fixes
+
+* Ensure curl uses HTTP version 1.1 as a workaround for [#33](https://github.com/bugsnag/bugsnag-dsym-upload/issues/33)
+  [#36](https://github.com/bugsnag/bugsnag-dsym-upload/pull/36)
+
 ## 1.4.1 (2018-12-17)
 
 ### Bug fixes

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'bugsnag-maze-runner', :git => 'https://github.com/bugsnag/maze-runner',
-                           :tag => 'v1.0.0'
+                           :tag => 'v1.1.0'

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -150,7 +150,7 @@ for dsym in $dsym_dir/*.dSYM; do
 
             # We need to shell out to perform the curl as there seems to be some indirect
             # wrapping of this script which causes the command to fail if called directly.
-            curl_cmd="curl --silent --show-error $upload_server -F dsym=@\"$file\" $args"
+            curl_cmd="curl --silent --show-error --http1.1 $upload_server -F dsym=@\"$file\" $args"
             output=$(sh -c "$curl_cmd")
 
             if [ $? -eq 0 ] && [ "$output" != "invalid apiKey" ]; then

--- a/features/dsym_upload.feature
+++ b/features/dsym_upload.feature
@@ -3,31 +3,37 @@ Feature: Uploading dSYMs to Bugsnag
     Scenario: Uploading a directory of dSYM files
         When I upload dSYMS with options "features/fixtures"
         Then I should receive a request
-        And the part "dsym" for request 0 is not null
+        And the HTTP version is "1.1" for request 0
+        And the field "dsym" for multipart request 0 is not null
 
     Scenario: Uploading a zip file containing dSYM files
         When I upload dSYMS with options "features/fixtures/dsyms.zip"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "dsym" for request 1 is not null
+        And the HTTP version is "1.1" for request 0
+        And the HTTP version is "1.1" for request 1
+        And the field "dsym" for multipart request 0 is not null
+        And the field "dsym" for multipart request 1 is not null
 
     Scenario: Uploading dSYMs with a project root
         When I upload dSYMS with options "--project-root /Users/jenkins/build/app/ features/fixtures"
         Then I should receive a request
-        And the part "dsym" for request 0 is not null
-        And the part "projectRoot" for request 0 equals "/Users/jenkins/build/app/"
+        And the HTTP version is "1.1" for request 0
+        And the field "dsym" for multipart request 0 is not null
+        And the field "projectRoot" for multipart request 0 equals "/Users/jenkins/build/app/"
         And the payload field "apiKey" is null for request 0
 
     Scenario: Uploading dSYMs with API key
         When I upload dSYMS with options "--api-key 1234567890ABCDEF features/fixtures"
         Then I should receive a request
-        And the part "dsym" for request 0 is not null
-        And the part "apiKey" for request 0 equals "1234567890ABCDEF"
+        And the HTTP version is "1.1" for request 0
+        And the field "dsym" for multipart request 0 is not null
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF"
         And the payload field "projectRoot" is null for request 0
 
     Scenario: Uploading dSYMs with a project root and API key
         When I upload dSYMS with options "--project-root /Users/jenkins/build/app/ --api-key 1234567890ABCDEF features/fixtures"
         Then I should receive a request
-        And the part "dsym" for request 0 is not null
-        And the part "projectRoot" for request 0 equals "/Users/jenkins/build/app/"
-        And the part "apiKey" for request 0 equals "1234567890ABCDEF"
+        And the HTTP version is "1.1" for request 0
+        And the field "dsym" for multipart request 0 is not null
+        And the field "projectRoot" for multipart request 0 equals "/Users/jenkins/build/app/"
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF"

--- a/features/fastlane_dsym_upload.feature
+++ b/features/fastlane_dsym_upload.feature
@@ -3,44 +3,44 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
     Scenario: Uploading dSYMs from a single zip file
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "dsym" for request 1 is not null
+        And the field "dsym" for multipart request 0 is not null
+        And the field "dsym" for multipart request 1 is not null
 
     Scenario: Uploading dSYMs from an array of paths
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip,dsym2.zip"
         Then I should receive 4 requests
-        And the part "dsym" for request 0 is not null
-        And the part "dsym" for request 1 is not null
-        And the part "dsym" for request 2 is not null
-        And the part "dsym" for request 3 is not null
+        And the field "dsym" for multipart request 0 is not null
+        And the field "dsym" for multipart request 1 is not null
+        And the field "dsym" for multipart request 2 is not null
+        And the field "dsym" for multipart request 3 is not null
 
     Scenario: Uploading dSYMs from a directory
         When I run lane "upload_symbols" with dsym_path set to "dsyms/"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "dsym" for request 1 is not null
+        And the field "dsym" for multipart request 0 is not null
+        And the field "dsym" for multipart request 1 is not null
 
     Scenario: Uploading dSYMs with a zip filename containing spaces and special characters
         When I run lane "upload_symbols" with dsym_path set to "some dir/some files β.app.dSYM.zip"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "dsym" for request 1 is not null
+        And the field "dsym" for multipart request 0 is not null
+        And the field "dsym" for multipart request 1 is not null
 
     Scenario: Uploading dSYMs using API key and config file together uses api key from config file
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip", api_key set to "1234567890abcde" and config_file set to "TestList.plist"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "apiKey" for request 0 equals "random-key"
-        And the part "dsym" for request 1 is not null
-        And the part "apiKey" for request 1 equals "random-key"
+        And the field "dsym" for multipart request 0 is not null
+        And the field "apiKey" for multipart request 0 equals "random-key"
+        And the field "dsym" for multipart request 1 is not null
+        And the field "apiKey" for multipart request 1 equals "random-key"
 
     Scenario: Uploading dSYMs using API key and empty config file
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip", api_key set to "1234567890ABCDEF1234567890ABCDEF" and config_file set to "NoApiKey.plist"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "apiKey" for request 0 equals "1234567890ABCDEF1234567890ABCDEF"
-        And the part "dsym" for request 1 is not null
-        And the part "apiKey" for request 1 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 0 is not null
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 1 is not null
+        And the field "apiKey" for multipart request 1 equals "1234567890ABCDEF1234567890ABCDEF"
 
     Scenario: Uploading dSYMs with an invalid API key as a parameter
         When I run lane "upload_symbols_with_api_key" with dsym_path set to "dsyms/" and api_key set to "invalid-key"
@@ -49,20 +49,20 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
     Scenario: Uploading dSYMs with an valid API key as a parameter
         When I run lane "upload_symbols_with_api_key" with dsym_path set to "dsyms/" and api_key set to "1234567890ABCDEF1234567890ABCDEF"
         Then I should receive 2 requests
-        And the part "dsym" for request 0 is not null
-        And the part "apiKey" for request 0 equals "1234567890ABCDEF1234567890ABCDEF"
-        And the part "dsym" for request 1 is not null
-        And the part "apiKey" for request 1 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 0 is not null
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 1 is not null
+        And the field "apiKey" for multipart request 1 equals "1234567890ABCDEF1234567890ABCDEF"
 
     Scenario: Uploading dSYMs using shared values from other plugins
         When I run lane "upload_symbols_with_custom_action" with api_key set to "1234567890ABCDEF1234567890ABCDEF"
         Then I should receive 4 request
-        And the part "dsym" for request 0 is not null
-        And the part "apiKey" for request 0 equals "1234567890ABCDEF1234567890ABCDEF"
-        And the part "dsym" for request 1 is not null
-        And the part "apiKey" for request 1 equals "1234567890ABCDEF1234567890ABCDEF"
-        And the part "dsym" for request 2 is not null
-        And the part "apiKey" for request 2 equals "1234567890ABCDEF1234567890ABCDEF"
-        And the part "dsym" for request 3 is not null
-        And the part "apiKey" for request 3 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 0 is not null
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 1 is not null
+        And the field "apiKey" for multipart request 1 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 2 is not null
+        And the field "apiKey" for multipart request 2 equals "1234567890ABCDEF1234567890ABCDEF"
+        And the field "dsym" for multipart request 3 is not null
+        And the field "apiKey" for multipart request 3 equals "1234567890ABCDEF1234567890ABCDEF"
 


### PR DESCRIPTION
This should address this issue: https://github.com/bugsnag/bugsnag-dsym-upload/issues/33