### PR TITLE
Fix: Invalid test and invalid APIKey message

### DIFF
--- a/features/fastlane_dsym_upload.feature
+++ b/features/fastlane_dsym_upload.feature
@@ -35,12 +35,12 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the part "apiKey" for request 1 equals "random-key"
 
     Scenario: Uploading dSYMs using API key and empty config file
-        When I run lane "upload_symbols" with dsym_path set to "dsyms.zip", api_key set to "1234567890abcde" and config_file set to "NoApiKey.plist"
+        When I run lane "upload_symbols" with dsym_path set to "dsyms.zip", api_key set to "1234567890ABCDEF1234567890ABCDEF" and config_file set to "NoApiKey.plist"
         Then I should receive 2 requests
         And the part "dsym" for request 0 is not null
-        And the part "apiKey" for request 0 equals "1234567890abcde"
+        And the part "apiKey" for request 0 equals "1234567890ABCDEF1234567890ABCDEF"
         And the part "dsym" for request 1 is not null
-        And the part "apiKey" for request 1 equals "1234567890abcde"
+        And the part "apiKey" for request 1 equals "1234567890ABCDEF1234567890ABCDEF"
 
     Scenario: Uploading dSYMs with an invalid API key as a parameter
         When I run lane "upload_symbols_with_api_key" with dsym_path set to "dsyms/" and api_key set to "invalid-key"

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -75,7 +75,7 @@ module Fastlane
           return if key.nil?
 
           unless !key[/\H/] and key.length == 32
-            UI.user_error!("API key should be a 32 character hexdeciaml string")
+            UI.user_error!("API key should be a 32 character hexadecimal string")
           end
         end
 


### PR DESCRIPTION
## Goal

- Fixes broken Maze-runner scenario
- Fixes typo in invalid APIKey message