### PR TITLE
Set a non zero exit code on upload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBD (2020-07-24)
+
+### Enhancements
+
+* Ensure `curl` sets a non-zero exit code on failure.
+  [#39](https://github.com/bugsnag/bugsnag-dsym-upload/pull/39)
+
 ## 1.4.2 (2020-04-02)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## TBD (2020-07-24)
+## TBD
 
 ### Enhancements
 

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -150,7 +150,7 @@ for dsym in $dsym_dir/*.dSYM; do
 
             # We need to shell out to perform the curl as there seems to be some indirect
             # wrapping of this script which causes the command to fail if called directly.
-            curl_cmd="curl --silent --show-error --http1.1 $upload_server -F dsym=@\"$file\" $args"
+            curl_cmd="curl --fail --silent --show-error --http1.1 $upload_server -F dsym=@\"$file\" $args"
             output=$(sh -c "$curl_cmd")
 
             if [ $? -eq 0 ] && [ "$output" != "invalid apiKey" ]; then


### PR DESCRIPTION
Fixes #38.

Tested with the following,

```bash
bin/bugsnag-dsym-upload --upload-server https://httpstat.us/503 dsym_archive_test.zip && echo success

Uploading UUID: 04E51379-A668-3ECA-975C-50EE0D2921CA (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/04E51379-A668-3ECA-975C-50EE0D2921CA.dSYM/Contents/Resources/DWARF/libswiftCoreImage.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 1066EDB0-4E4E-393D-845B-50BFDE11191A (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/1066EDB0-4E4E-393D-845B-50BFDE11191A.dSYM/Contents/Resources/DWARF/libswiftCoreImage.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 14D5AAC3-E157-3015-9302-442161BA272E (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/14D5AAC3-E157-3015-9302-442161BA272E.dSYM/Contents/Resources/DWARF/libswiftUIKit.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 289F600E-8605-3D5A-89A6-8786BFE2D58D (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/289F600E-8605-3D5A-89A6-8786BFE2D58D.dSYM/Contents/Resources/DWARF/libswiftDarwin.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 3A22AA68-B3B6-3076-AB63-154FE3F0ED0F (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/3A22AA68-B3B6-3076-AB63-154FE3F0ED0F.dSYM/Contents/Resources/DWARF/libswiftDispatch.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 412AD5C2-A5B6-3EC1-8C9C-5629E4D983A6 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/412AD5C2-A5B6-3EC1-8C9C-5629E4D983A6.dSYM/Contents/Resources/DWARF/libswiftCore.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 4BC83911-F817-3475-BAC9-B154D7C8CF0B (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/4BC83911-F817-3475-BAC9-B154D7C8CF0B.dSYM/Contents/Resources/DWARF/libswiftCore.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 8039D68A-06AA-38B6-AA20-9E48819644D5 (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/8039D68A-06AA-38B6-AA20-9E48819644D5.dSYM/Contents/Resources/DWARF/bugsnag-example
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 8C7ACF0A-DB82-3755-BC7E-A664C7B9B60B (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/8C7ACF0A-DB82-3755-BC7E-A664C7B9B60B.dSYM/Contents/Resources/DWARF/libswiftUIKit.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 9189028A-7DB8-3771-B939-8D6CE575BC9B (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/9189028A-7DB8-3771-B939-8D6CE575BC9B.dSYM/Contents/Resources/DWARF/libswiftCoreGraphics.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 9E90E073-F509-3383-9A11-C86773C680E6 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/9E90E073-F509-3383-9A11-C86773C680E6.dSYM/Contents/Resources/DWARF/bugsnag-example
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: 9F9D30DF-41B9-3F60-B8A6-8D8353904C22 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/9F9D30DF-41B9-3F60-B8A6-8D8353904C22.dSYM/Contents/Resources/DWARF/libswiftQuartzCore.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: BDA876C8-6DE3-3A09-BECA-4B29FBE77193 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/BDA876C8-6DE3-3A09-BECA-4B29FBE77193.dSYM/Contents/Resources/DWARF/libswiftDarwin.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: C92AF44A-6C4A-3057-AFC1-5102CF33739B (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/C92AF44A-6C4A-3057-AFC1-5102CF33739B.dSYM/Contents/Resources/DWARF/libswiftDispatch.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: CA8A2708-2A8A-3404-B5DF-DC044FC8B2C4 (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/CA8A2708-2A8A-3404-B5DF-DC044FC8B2C4.dSYM/Contents/Resources/DWARF/libswiftQuartzCore.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: CF864347-A083-3324-8A74-5B535837EE96 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/CF864347-A083-3324-8A74-5B535837EE96.dSYM/Contents/Resources/DWARF/libswiftObjectiveC.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: D34FD74B-45C6-3EFB-B665-5D73DC7DAFA6 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/D34FD74B-45C6-3EFB-B665-5D73DC7DAFA6.dSYM/Contents/Resources/DWARF/libswiftCoreGraphics.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: E24763FA-7629-3669-8678-D6F6DE1451D9 (armv7) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/E24763FA-7629-3669-8678-D6F6DE1451D9.dSYM/Contents/Resources/DWARF/libswiftFoundation.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: EF889A99-DDB5-3264-BDA4-836A39557D0F (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/EF889A99-DDB5-3264-BDA4-836A39557D0F.dSYM/Contents/Resources/DWARF/libswiftObjectiveC.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


Uploading UUID: F88D5870-EA71-3629-BF3E-EC28BED21647 (arm64) /var/folders/0y/bts_0rzj5q91dn9y1wdjgcjh0000gn/T/bugsnag-dsym-upload.XXX.mPkY7YEL/F88D5870-EA71-3629-BF3E-EC28BED21647.dSYM/Contents/Resources/DWARF/libswiftFoundation.dylib
curl: (22) The requested URL returned error: 503 Service Unavailable


20 files failed to upload
```

Success case also tested and works as expected.

I looked into adding tests but I couldn't see that the testing framework allows verifying exit codes.