### PR TITLE
chore: fix build warnings

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,10 @@
-Bundler.with_clean_env do
+Bundler.with_original_env do
   Dir.chdir 'tools/fastlane-plugin' do
     `rake build`
   end
 end
 
-Bundler.with_clean_env do
+Bundler.with_original_env do
   Dir.chdir 'features/fixtures/fl-project' do
     gem_path = Dir['../../../tools/fastlane-plugin/fastlane-plugin-bugsnag-*.gem'].last
     `bundle config --local path vendor`
@@ -18,7 +18,7 @@ def fastlane_upload_symbols(lane, dsym_path=nil, api_key=nil, config_file=nil)
   config_file_env = "BUGSNAG_CONFIG_FILE='#{config_file}'" unless config_file.nil?
   dsym_path_env = "BUGSNAG_DSYM_PATH='#{dsym_path}'" unless dsym_path.nil?
 
-  Bundler.with_clean_env do
+  Bundler.with_original_env do
     Dir.chdir 'features/fixtures/fl-project' do
       `BUGSNAG_ENDPOINT='http://localhost:#{MOCK_API_PORT}'\
        #{dsym_path_env} \

--- a/tools/fastlane-plugin/fastlane-plugin-bugsnag.gemspec
+++ b/tools/fastlane-plugin/fastlane-plugin-bugsnag.gemspec
@@ -6,8 +6,8 @@ require 'fastlane/plugin/bugsnag/version'
 Gem::Specification.new do |spec|
   spec.name          = 'fastlane-plugin-bugsnag'
   spec.version       = Fastlane::Bugsnag::VERSION
-  spec.author        = %q{Delisa Mason}
-  spec.email         = %q{iskanamagus@gmail.com}
+  spec.author        = %q{Bugsnag}
+  spec.email         = %q{support@bugsnag.com}
 
   spec.summary       = %q{Uploads dSYM files to Bugsnag}
   spec.homepage      = "https://github.com/bugsnag/bugsnag-upload"
@@ -17,13 +17,13 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.test_files    = Dir["spec/**/*"]
 
-  spec.add_runtime_dependency 'xml-simple'
-  spec.add_runtime_dependency 'git'
+  spec.add_runtime_dependency 'xml-simple', '~> 1'
+  spec.add_runtime_dependency 'git', '~> 1'
 
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'fastlane', '>= 2.28.5'
+  spec.add_development_dependency 'pry', '~> 0'
+  spec.add_development_dependency 'bundler', '~> 2'
+  spec.add_development_dependency 'rspec', '~> 3'
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'rubocop', '~> 0'
+  spec.add_development_dependency 'fastlane', '>= 2.28.5', '< 3.0'
 end


### PR DESCRIPTION
## Goal

Fixes reported build warnings by limiting gem versions and replacing deprecated `Bundler.with_clean_env`.