### PR TITLE
ci: restrict parallel gem version to support ruby 2.4.x

### DIFF
--- a/tools/fastlane-plugin/fastlane-plugin-bugsnag.gemspec
+++ b/tools/fastlane-plugin/fastlane-plugin-bugsnag.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'parallel', '< 1.20.0'
   spec.add_development_dependency 'fastlane', '>= 2.28.5'
 end


### PR DESCRIPTION
## Goal

The latest parallel gem ([1.20.0](https://rubygems.org/gems/parallel/versions/1.20.0)) has dropped support for Ruby 2.4. Added a restriction on the dependency, which is included through rubocop (~> 1.10).

## Testing

Re-running CI