### PR TITLE
fix(cli tool): Check for 0 byte dSYM file, and throw a warning if found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Throw warning if 0 byte dSYM file is attempted to be uploaded
   [#52](https://github.com/bugsnag/bugsnag-dsym-upload/pull/52)
 
+* Files found with `Dir.glob` are now sorted alphabetically so that this action is deterministic accross OS's
+  [#57](https://github.com/bugsnag/bugsnag-dsym-upload/pull/57)
+
 ## 2.0.0 (2020-08-13)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## TBC (TBC)
+
+### Enhancements
+
+* Throw warning if 0 byte dSYM file is attempted to be uploaded
+  [#52](https://github.com/bugsnag/bugsnag-dsym-upload/pull/52)
+
 ## 2.0.0 (2020-08-13)
 
 ### Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,17 +23,16 @@ Open the `tools/fastlane-plugin` directory, then:
 ## Releasing a new version
 
 1. Update the CHANGELOG with new content
-2. Update the version number
-   * Homebrew:
-      * Create a new Pull Request on the Bugsnag Homebrew tap repo `bugsnag/homebrew-bugsnag-tap` and update `Formula/bugsnag-dsym-upload.rb` with the following:
-      * Update the `url` in the formula to the new `.tar.gz` release
-      * Update the `sha256` checksum value in the formula. You can get this by creating a new formula with `brew create <link_to_new_.tar.gz>`
+2. Update the version numbers:
    * Update the version in `VERSION`
-   * Update the version in
-     `tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/version.rb`
+   * Update the version in `tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/version.rb`
 3. Commit your changes
 4. Tag the release
-5. Push
+5. Push:
    * Create a new GitHub release with the changes
    * Open `tools/fastlane-plugin` and run `rake release`
-6. Update the documentation as needed on docs.bugsnag.com
+6. Homebrew:
+   * Create a new Pull Request on the Bugsnag Homebrew tap repo `bugsnag/homebrew-tap` and update `Formula/bugsnag-dsym-upload.rb` with the following:
+   * Update the `url` in the formula to the new `.tar.gz` release
+   * Update the `sha256` checksum value in the formula. You can get this by creating a new formula with `brew create <link_to_new_.tar.gz>`
+7. Update the documentation as needed on docs.bugsnag.com

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -127,7 +127,7 @@ for dsym in $dsym_dir/*.dSYM; do
     # This can happen due to a bug in Xcode: https://developer.apple.com/forums/thread/659187
     if [ -f $dsym ]; then
         dsym_size=$(wc -c < "$dsym" | xargs)
-        log_verbose "Skipping $dsym as it's is a file ($dsym_size bytes), not a directory with DWARF data";
+        log_verbose "[WARNING] Skipping $dsym as it's is a file ($dsym_size bytes), not a directory with DWARF data";
         warning_count=$((warning_count+1))
         continue
     fi
@@ -139,7 +139,7 @@ for dsym in $dsym_dir/*.dSYM; do
 
     dwarf_data=$dsym/Contents/Resources/DWARF
     if [[ ! -d $dwarf_data ]]; then
-        log_verbose "Skipping file missing DWARF data: $dsym"
+        log_verbose "[ERROR] Skipping file missing DWARF data: $dsym"
         fail_count=$((fail_count+1))
         continue
     fi
@@ -167,12 +167,12 @@ for dsym in $dsym_dir/*.dSYM; do
                 success_count=$((success_count+1))
             else
                 fail_count=$((fail_count+1))
-                log_verbose "Failed to upload file: $file"
+                log_verbose "[ERROR] Failed to upload file: $file"
             fi
             echo $output | grep -v '^OK$'
             log
         else
-            log_verbose "Skipping file without UUID: $file"
+            log_verbose "[ERROR] Skipping file without UUID: $file"
             fail_count=$((fail_count+1))
         fi
     done

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -178,11 +178,22 @@ for dsym in $dsym_dir/*.dSYM; do
     done
 done
 
+exit_code=0
 if [ $success_count -gt 0 ]; then
-    log "$success_count files uploaded successfully"
+    log "$success_count file(s) uploaded successfully"
+fi
+
+if [ $warning_count -gt 0 ]; then
+    log "$warning_count file(s) failed to upload with warnings"
 fi
 
 if [ $fail_count -gt 0 ]; then
-    log "$fail_count files failed to upload"
-    exit 1
+    exit_code=1
+    log "$fail_count file(s) failed to upload with errors"
 fi
+
+if [ $fail_count -gt 0 ] || [ $warning_count -gt 0 ]; then
+    log "Re-run the bugsnag-dsym-upload tool with the --verbose option for more information"
+fi
+
+exit $exit_code

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -117,10 +117,20 @@ fi
 
 log_verbose "Uploading files to $upload_server"
 success_count=0
+warning_count=0
 fail_count=0
 
 for dsym in $dsym_dir/*.dSYM; do
     log_verbose "Preparing to upload $dsym"
+
+    # check if the .dSYM is a file. Throw a warning if detected as such; it should be a directory
+    # This can happen due to a bug in Xcode: https://developer.apple.com/forums/thread/659187
+    if [ -f $dsym ]; then
+        dsym_size=$(wc -c < "$dsym" | xargs)
+        log_verbose "Skipping $dsym as it's is a file ($dsym_size bytes), not a directory with DWARF data";
+        warning_count=$((warning_count+1))
+        continue
+    fi
 
     if [[ -d $symbol_maps ]]; then
         log_verbose "Updating file with bitcode symbol maps in $symbol_maps"

--- a/bin/bugsnag-dsym-upload
+++ b/bin/bugsnag-dsym-upload
@@ -192,7 +192,7 @@ if [ $fail_count -gt 0 ]; then
     log "$fail_count file(s) failed to upload with errors"
 fi
 
-if [ $fail_count -gt 0 ] || [ $warning_count -gt 0 ]; then
+if [[ $fail_count -gt 0 || $warning_count -gt 0 ]] && [[ $verbose != 1 ]]; then
     log "Re-run the bugsnag-dsym-upload tool with the --verbose option for more information"
 fi
 

--- a/features/dsym_upload.feature
+++ b/features/dsym_upload.feature
@@ -5,6 +5,7 @@ Feature: Uploading dSYMs to Bugsnag
         Then I should receive a request
         And the HTTP version is "1.1" for request 0
         And the field "dsym" for multipart request 0 is not null
+        Then the exit status should be 0
 
     Scenario: Uploading a zip file containing dSYM files
         When I upload dSYMS with options "features/fixtures/dsyms.zip"
@@ -13,6 +14,7 @@ Feature: Uploading dSYMs to Bugsnag
         And the HTTP version is "1.1" for request 1
         And the field "dsym" for multipart request 0 is not null
         And the field "dsym" for multipart request 1 is not null
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs with a project root
         When I upload dSYMS with options "--project-root /Users/jenkins/build/app/ features/fixtures"
@@ -21,6 +23,7 @@ Feature: Uploading dSYMs to Bugsnag
         And the field "dsym" for multipart request 0 is not null
         And the field "projectRoot" for multipart request 0 equals "/Users/jenkins/build/app/"
         And the payload field "apiKey" is null for request 0
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs with API key
         When I upload dSYMS with options "--api-key 1234567890ABCDEF features/fixtures"
@@ -29,6 +32,7 @@ Feature: Uploading dSYMs to Bugsnag
         And the field "dsym" for multipart request 0 is not null
         And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF"
         And the payload field "projectRoot" is null for request 0
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs with a project root and API key
         When I upload dSYMS with options "--project-root /Users/jenkins/build/app/ --api-key 1234567890ABCDEF features/fixtures"
@@ -37,3 +41,4 @@ Feature: Uploading dSYMs to Bugsnag
         And the field "dsym" for multipart request 0 is not null
         And the field "projectRoot" for multipart request 0 equals "/Users/jenkins/build/app/"
         And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF"
+        Then the exit status should be 0

--- a/features/fastlane_dsym_upload.feature
+++ b/features/fastlane_dsym_upload.feature
@@ -65,3 +65,13 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the field "apiKey" for multipart request 2 equals "1234567890ABCDEF1234567890ABCDEF"
         And the field "dsym" for multipart request 3 is not null
         And the field "apiKey" for multipart request 3 equals "1234567890ABCDEF1234567890ABCDEF"
+
+    Scenario: Skipping over a zero byte dSYM with warning
+        When I run lane "upload_symbols" with dsym_path set to "ZeroByteDsym/"
+        Then I should receive 0 requests
+        Then the exit status should be 0
+
+    Scenario: Throw failure if dSYM is missing DWARF data
+        When I run lane "upload_symbols" with dsym_path set to "MissingDWARFdSYM/"
+        Then I should receive 0 requests
+        Then the exit status should be 1

--- a/features/fastlane_dsym_upload.feature
+++ b/features/fastlane_dsym_upload.feature
@@ -5,6 +5,7 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         Then I should receive 2 requests
         And the field "dsym" for multipart request 0 is not null
         And the field "dsym" for multipart request 1 is not null
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs from an array of paths
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip,dsym2.zip"
@@ -13,18 +14,21 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the field "dsym" for multipart request 1 is not null
         And the field "dsym" for multipart request 2 is not null
         And the field "dsym" for multipart request 3 is not null
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs from a directory
         When I run lane "upload_symbols" with dsym_path set to "dsyms/"
         Then I should receive 2 requests
         And the field "dsym" for multipart request 0 is not null
         And the field "dsym" for multipart request 1 is not null
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs with a zip filename containing spaces and special characters
         When I run lane "upload_symbols" with dsym_path set to "some dir/some files β.app.dSYM.zip"
         Then I should receive 2 requests
         And the field "dsym" for multipart request 0 is not null
         And the field "dsym" for multipart request 1 is not null
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs using API key and config file together uses api key from input parameter
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip", api_key set to "1234567890ABCDEF1234567890AAAAAA" and config_file set to "TestList.plist"
@@ -33,6 +37,7 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890AAAAAA"
         And the field "dsym" for multipart request 1 is not null
         And the field "apiKey" for multipart request 1 equals "1234567890ABCDEF1234567890AAAAAA"
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs using API key and empty config file
         When I run lane "upload_symbols" with dsym_path set to "dsyms.zip", api_key set to "1234567890ABCDEF1234567890ABCDEF" and config_file set to "NoApiKey.plist"
@@ -41,10 +46,12 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890ABCDEF"
         And the field "dsym" for multipart request 1 is not null
         And the field "apiKey" for multipart request 1 equals "1234567890ABCDEF1234567890ABCDEF"
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs with an invalid API key as a parameter
         When I run lane "upload_symbols_with_api_key" with dsym_path set to "dsyms/" and api_key set to "invalid-key"
         Then I should receive 0 requests
+        Then the exit status should be 1
 
     Scenario: Uploading dSYMs with an valid API key as a parameter
         When I run lane "upload_symbols_with_api_key" with dsym_path set to "dsyms/" and api_key set to "1234567890ABCDEF1234567890ABCDEF"
@@ -53,6 +60,7 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890ABCDEF"
         And the field "dsym" for multipart request 1 is not null
         And the field "apiKey" for multipart request 1 equals "1234567890ABCDEF1234567890ABCDEF"
+        Then the exit status should be 0
 
     Scenario: Uploading dSYMs using shared values from other plugins
         When I run lane "upload_symbols_with_custom_action" with api_key set to "1234567890ABCDEF1234567890ABCDEF"
@@ -65,6 +73,7 @@ Feature: Uploading dSYMs to Bugsnag using Fastlane
         And the field "apiKey" for multipart request 2 equals "1234567890ABCDEF1234567890ABCDEF"
         And the field "dsym" for multipart request 3 is not null
         And the field "apiKey" for multipart request 3 equals "1234567890ABCDEF1234567890ABCDEF"
+        Then the exit status should be 0
 
     Scenario: Skipping over a zero byte dSYM with warning
         When I run lane "upload_symbols" with dsym_path set to "ZeroByteDsym/"

--- a/features/fixtures/fl-project/MissingDWARFdSYM/MissingDWARF.dSYM/Contents/Info.plist
+++ b/features/fixtures/fl-project/MissingDWARFdSYM/MissingDWARF.dSYM/Contents/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>English</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.apple.xcode.dsym.com.xljones.XCFTest</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundlePackageType</key>
+		<string>dSYM</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+	</dict>
+</plist>

--- a/features/steps/fastlane_steps.rb
+++ b/features/steps/fastlane_steps.rb
@@ -22,6 +22,5 @@ When("I run lane {string} with dsym_path set to {string}, api_key set to {string
 end
 
 Then("the exit status should be {int}") do |int|
-  # return the last exit code
   assert_equal($?.exitstatus, int)
 end

--- a/features/steps/fastlane_steps.rb
+++ b/features/steps/fastlane_steps.rb
@@ -22,5 +22,5 @@ When("I run lane {string} with dsym_path set to {string}, api_key set to {string
 end
 
 Then("the exit status should be {int}") do |int|
-  assert_equal($?.exitstatus, int)
+  assert_equal(int, $?.exitstatus)
 end

--- a/features/steps/fastlane_steps.rb
+++ b/features/steps/fastlane_steps.rb
@@ -20,3 +20,8 @@ end
 When("I run lane {string} with dsym_path set to {string}, api_key set to {string} and config_file set to {string}") do |lane, dsym_path, api_key, config_file|
   fastlane_upload_symbols(lane, dsym_path, api_key, config_file)
 end
+
+Then("the exit status should be {int}") do |int|
+  # return the last exit code
+  assert_equal($?.exitstatus, int)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,10 @@
-Bundler.with_unbundled_env do
+Bundler.with_clean_env do
   Dir.chdir 'tools/fastlane-plugin' do
     `rake build`
   end
 end
 
-Bundler.with_unbundled_env do
+Bundler.with_clean_env do
   Dir.chdir 'features/fixtures/fl-project' do
     gem_path = Dir['../../../tools/fastlane-plugin/fastlane-plugin-bugsnag-*.gem'].last
     `bundle config --local path vendor`
@@ -18,7 +18,7 @@ def fastlane_upload_symbols(lane, dsym_path=nil, api_key=nil, config_file=nil)
   config_file_env = "BUGSNAG_CONFIG_FILE='#{config_file}'" unless config_file.nil?
   dsym_path_env = "BUGSNAG_DSYM_PATH='#{dsym_path}'" unless dsym_path.nil?
 
-  Bundler.with_unbundled_env do
+  Bundler.with_clean_env do
     Dir.chdir 'features/fixtures/fl-project' do
       `BUGSNAG_ENDPOINT='http://localhost:#{MOCK_API_PORT}'\
        #{dsym_path_env} \

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,7 +24,7 @@ def fastlane_upload_symbols(lane, dsym_path=nil, api_key=nil, config_file=nil)
        #{dsym_path_env} \
        #{api_key_env} \
        #{config_file_env} \
-       bundle exec fastlane #{lane} --verbose`
+       bundle exec fastlane #{lane}`
     end
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,7 +24,7 @@ def fastlane_upload_symbols(lane, dsym_path=nil, api_key=nil, config_file=nil)
        #{dsym_path_env} \
        #{api_key_env} \
        #{config_file_env} \
-       bundle exec fastlane #{lane}`
+       bundle exec fastlane #{lane} --verbose`
     end
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,10 @@
-Bundler.with_clean_env do
+Bundler.with_unbundled_env do
   Dir.chdir 'tools/fastlane-plugin' do
     `rake build`
   end
 end
 
-Bundler.with_clean_env do
+Bundler.with_unbundled_env do
   Dir.chdir 'features/fixtures/fl-project' do
     gem_path = Dir['../../../tools/fastlane-plugin/fastlane-plugin-bugsnag-*.gem'].last
     `bundle config --local path vendor`
@@ -18,7 +18,7 @@ def fastlane_upload_symbols(lane, dsym_path=nil, api_key=nil, config_file=nil)
   config_file_env = "BUGSNAG_CONFIG_FILE='#{config_file}'" unless config_file.nil?
   dsym_path_env = "BUGSNAG_DSYM_PATH='#{dsym_path}'" unless dsym_path.nil?
 
-  Bundler.with_clean_env do
+  Bundler.with_unbundled_env do
     Dir.chdir 'features/fixtures/fl-project' do
       `BUGSNAG_ENDPOINT='http://localhost:#{MOCK_API_PORT}'\
        #{dsym_path_env} \


### PR DESCRIPTION
## Goal

Due to an (unconfirmed) bug in Xcode (https://developer.apple.com/forums/thread/659187), 0 byte dSYMs can be generated by Xcode. These show up as `filename.dSYM` _files_ rather than `dirname.dSYM` _directories_ (which contain the DWARF data of interest, normally). 

## Design

* Adds a check for whether each dSYM is a file (and additionally calculates its size if so for support purposes)
* Prompts the user to run with `--verbose` if failures or warnings are presented.

## Changeset

* Main `bugsnag-dsym-upload` binary is modified to catch dSYM files, and throw warning.
* Changed calls of `Bundler.with_clean_env` to `Bundler.with_unbundled_env` due to deprecation.

## Further consideration

* If not in verbose mode, the warnings won't be shown – should these be shown regardless of verbosity?
* Should DWARF files without UUID also be considered warnings instead of failures?
* Should dSYMS with missing DWARF files be considered warnings instead of failures?

## Testing

* Updated automated tests to throw examples of 0b dSYMs and show they're skipped without causing an error code to be thrown
* Additionally added automated test for missing DWARF data dSYMs (these do throw errors, exit code 1)

### CLI

Manually tested with 4 different dSYM folders: 

* `dsym_test_ok`: contains one dSYM with known acceptable DWARF data
```
$ ./bugsnag-dsym-upload --verbose --api-key 0c0ea7242a829310a625f599db2e5752 ./dsyms_test_ok
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test_ok/Bugsnag.framework.dSYM
Uploading UUID: E599CF69-D848-3ED2-9093-68A44234CFCF (armv7) ./dsyms_test_ok/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag UUID: 40112A5E-4A23-37EC-9A5D-95AF2C18AE39 (arm64) ./dsyms_test_ok/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag

1 file(s) uploaded successfully
```
Checking exit code of last command run (expecting `0`):
```
echo $?
0
```

* `dsym_test_warning`: contains one dSYM file that's 0 bytes
```
$ ./bugsnag-dsym-upload --verbose --api-key 0c0ea7242a829310a625f599db2e5752 ./dsyms_test_warning
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test_warning/REDACTED.framework.ios-x86_64-maccatalyst.dSYM
Skipping ./dsyms_test_warning/REDACTED.framework.ios-x86_64-maccatalyst.dSYM as it's is a file (0 bytes), not a directory with DWARF data
1 file(s) failed to upload with warnings
Re-run the bugsnag-dsym-upload tool with the --verbose option for more information
```
Checking exit code of last command run (expecting `0`):
```
echo $?
0
```

* `dsym_test_error`: contains one dSYM with DWARF data removed (manually deleted)
```
$ ./bugsnag-dsym-upload --verbose --api-key 0c0ea7242a829310a625f599db2e5752 ./dsyms_test_error  
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test_error/bugsnag-example.app.dSYM
Skipping file without UUID: ./dsyms_test_error/bugsnag-example.app.dSYM/Contents/Resources/DWARF/*
1 file(s) failed to upload with errors
Re-run the bugsnag-dsym-upload tool with the --verbose option for more information
```
Checking exit code of last command run (expecting `1`):
```
echo $?
1
```

* `dsym_test`: contains 3 dSYMS from each of the directories above
```
$ ./bugsnag-dsym-upload --verbose --api-key 0c0ea7242a829310a625f599db2e5752 ./dsyms_test        
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test/Bugsnag.framework.dSYM
Uploading UUID: E599CF69-D848-3ED2-9093-68A44234CFCF (armv7) ./dsyms_test/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag UUID: 40112A5E-4A23-37EC-9A5D-95AF2C18AE39 (arm64) ./dsyms_test/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag

Preparing to upload ./dsyms_test/REDACTED.framework.ios-x86_64-maccatalyst.dSYM
Skipping ./dsyms_test/REDACTED.framework.ios-x86_64-maccatalyst.dSYM as it's is a file (0 bytes), not a directory with DWARF data
Preparing to upload ./dsyms_test/bugsnag-example.app.dSYM
Skipping file without UUID: ./dsyms_test/bugsnag-example.app.dSYM/Contents/Resources/DWARF/*
1 file(s) uploaded successfully
1 file(s) failed to upload with warnings
1 file(s) failed to upload with errors
Re-run the bugsnag-dsym-upload tool with the --verbose option for more information
```
Checking exit code of last command run  (expecting `1`):
```
echo $?
1
```

### Fastlane

This change affects Fastlane as the exit code is being manipulated. Using the same directories as above, and pointing the `Fastfile` to each directory independently:

* `dsym_test_ok`: contains one dSYM with known acceptable DWARF data
```
$ bundle exec fastlane ios release --verbose
...
DEBUG [2021-04-06 15:41:45.63]: Uploading dSYMs to Bugsnag with the following parameters:
DEBUG [2021-04-06 15:41:45.63]:              api_key: 0c0ea7242a829310a625f599db2e5752
DEBUG [2021-04-06 15:41:45.63]:            dsym_path: ["./dsyms_test_ok"]
...
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test_ok/Bugsnag.framework.dSYM
Uploading UUID: E599CF69-D848-3ED2-9093-68A44234CFCF (armv7) ./dsyms_test_ok/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag UUID: 40112A5E-4A23-37EC-9A5D-95AF2C18AE39 (arm64) ./dsyms_test_ok/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag

1 file(s) uploaded successfully
INFO [2021-04-06 15:41:48.21]: Uploaded dSYMs in ./dsyms_test_ok
...
INFO [2021-04-06 15:41:48.21]: fastlane.tools finished successfully 🎉
DEBUG [2021-04-06 15:41:48.21]: All plugins are up to date
```

* `dsym_test_warning`: contains one dSYM file that's 0 bytes
```
$ bundle exec fastlane ios release --verbose
...
DEBUG [2021-04-06 15:43:57.28]: Uploading dSYMs to Bugsnag with the following parameters:
DEBUG [2021-04-06 15:43:57.28]:              api_key: 0c0ea7242a829310a625f599db2e5752
DEBUG [2021-04-06 15:43:57.28]:            dsym_path: ["./dsyms_test_warning"]
...
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test_warning/REDACTED.framework.ios-x86_64-maccatalyst.dSYM
[WARNING] Skipping ./dsyms_test_warning/REDACTED.framework.ios-x86_64-maccatalyst.dSYM as it's is a file (0 bytes), not a directory with DWARF data
1 file(s) failed to upload with warnings
Re-run the bugsnag-dsym-upload tool with the --verbose option for more information
...
INFO [2021-04-06 15:43:57.30]: fastlane.tools finished successfully 🎉
```

* `dsym_test_error`: contains one dSYM with DWARF data removed (manually deleted)
```
$ bundle exec fastlane ios release --verbose
...
DEBUG [2021-04-06 15:47:12.39]: Uploading dSYMs to Bugsnag with the following parameters:
DEBUG [2021-04-06 15:47:12.39]:              api_key: 0c0ea7242a829310a625f599db2e5752
DEBUG [2021-04-06 15:47:12.39]:            dsym_path: ["./dsyms_test_error"]
...
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test_error/bugsnag-example.app.dSYM
[ERROR] Skipping file without UUID: ./dsyms_test_error/bugsnag-example.app.dSYM/Contents/Resources/DWARF/*
1 file(s) failed to upload with errors
Re-run the bugsnag-dsym-upload tool with the --verbose option for more information
...
ERROR [2021-04-06 15:47:12.41]: Failed uploading ./dsyms_test_error
...
FastlaneCore::Interface::FastlaneError: [!] Failed uploading ./dsyms_test_error
```

* `dsym_test`: contains 3 dSYMS from each of the directories above
```
$ bundle exec fastlane ios release --verbose
...
DEBUG [2021-04-06 15:50:34.36]: Uploading dSYMs to Bugsnag with the following parameters:
DEBUG [2021-04-06 15:50:34.36]:              api_key: 0c0ea7242a829310a625f599db2e5752
DEBUG [2021-04-06 15:50:34.36]:            dsym_path: ["./dsyms_test"]
...
Uploading files to https://upload.bugsnag.com
Preparing to upload ./dsyms_test/Bugsnag.framework.dSYM
Uploading UUID: E599CF69-D848-3ED2-9093-68A44234CFCF (armv7) ./dsyms_test/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag UUID: 40112A5E-4A23-37EC-9A5D-95AF2C18AE39 (arm64) ./dsyms_test/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag

Preparing to upload ./dsyms_test/REDACTED.framework.ios-x86_64-maccatalyst.dSYM
[WARNING] Skipping ./dsyms_test/REDACTED.framework.ios-x86_64-maccatalyst.dSYM as it's is a file (0 bytes), not a directory with DWARF data
Preparing to upload ./dsyms_test/bugsnag-example.app.dSYM
[ERROR] Skipping file without UUID: ./dsyms_test/bugsnag-example.app.dSYM/Contents/Resources/DWARF/*
1 file(s) uploaded successfully
1 file(s) failed to upload with warnings
1 file(s) failed to upload with errors
Re-run the bugsnag-dsym-upload tool with the --verbose option for more information
...
FastlaneCore::Interface::FastlaneError: [!] Failed uploading ./dsyms_test
```