### PR TITLE
License auditing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,6 @@
+steps:
+  - name: ':copyright: License Audit'
+    plugins:
+      docker-compose#v3.7.0:
+        run: license_finder
+    command: /bin/bash -lc '/scan/scripts/license_finder.sh'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'bugsnag-maze-runner', :git => 'https://github.com/bugsnag/maze-runner',
-                           :tag => 'v1.1.0'
+# Any :development dependencies are ignored for license auditing purposes
+group :development do
+end
+
+# Any :test dependencies are ignored for license auditing purposes
+group :test do
+  gem 'bugsnag-maze-runner', :git => 'https://github.com/bugsnag/maze-runner', :tag => 'v1.1.0'
+end

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+global.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.6'
+services:
+
+  license_finder:
+    build:
+      dockerfile: dockerfiles/Dockerfile.audit
+      context: .
+    volumes:
+      - ./:/scan

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,0 +1,5 @@
+FROM licensefinder/license_finder
+
+WORKDIR /scan
+
+CMD /scan/scripts/license_finder.sh

--- a/scripts/license_finder.sh
+++ b/scripts/license_finder.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/global.yml
+bundle install
+license_finder --decisions-file=config/global.yml


### PR DESCRIPTION
## Goal

Add license checking to the CI pipeline.  The existing pipeline is based in Travis, so I've set up the necessary webhook in Buildkite for this in order that we can take a consistent approach.