### PR TITLE
Fix false positives on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         bundle config path vendor/fastlane-bundle
         bundle install --gemfile=tools/fastlane-plugin/Gemfile
         cd tools/fastlane-plugin
-        bundle exec rake spec
+        bundle exec rspec
 
     - name: run MazeRunner (macOS only)
       if: contains(matrix.os, 'macos')

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bootstrap:
 	@cd tools/fastlane-plugin && bundle install
 
 test_unit:
-	@cd tools/fastlane-plugin && bundle exec rake spec
+	@cd tools/fastlane-plugin && bundle exec rspec
 
 test_features:
 	@bundle exec maze-runner -c features/*.feature

--- a/tools/fastlane-plugin/Rakefile
+++ b/tools/fastlane-plugin/Rakefile
@@ -1,8 +1,3 @@
-desc "Run the unit tests"
-task :spec do
-  system("rspec")
-end
-
 desc "Build the gem"
 task :build do
   # Copy required files into the gem
@@ -26,5 +21,3 @@ task :release => :build do
   require_relative 'lib/fastlane/plugin/bugsnag/version'
   system("gem push fastlane-plugin-bugsnag-#{Fastlane::Bugsnag::VERSION}.gem")
 end
-
-task default: :spec


### PR DESCRIPTION
## Goal

Running rspec via Rake is responsible for false positives on CI — `system` doesn't raise when the command fails, it returns `false` instead (unless the `exception` keyword argument is given)

Running rspec directly removes this layer of indirection and isn't any more complicated as we're not passing any options in the Rakefile anyway

This means the Ubuntu build is now failing as expected