### PR TITLE
Sort the possible plist paths before picking one

### DIFF
--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -245,12 +245,12 @@ module Fastlane
       end
 
       def self.default_android_manifest_path
-        Dir.glob("./{android/,}{app,}/src/main/AndroidManifest.xml").first
+        Dir.glob("./{android/,}{app,}/src/main/AndroidManifest.xml").sort.first
       end
 
       def self.load_options_from_xml file_path
         options = options_from_android_manifest(file_path)
-        build_gradle_path = Dir.glob("{android/,}app/build.gradle").first || Dir.glob("build.gradle").first
+        build_gradle_path = Dir.glob("{android/,}app/build.gradle").sort.first || Dir.glob("build.gradle").sort.first
         options.merge!(options_from_build_gradle(build_gradle_path)) if build_gradle_path
         return options
       end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -225,7 +225,7 @@ module Fastlane
       end
 
       def self.default_info_plist_path
-        Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }.first
+        Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }.sort.first
       end
 
       def self.load_options_from_plist file_path

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -125,7 +125,7 @@ module Fastlane
       def self.default_info_plist_path
         # Find first 'Info.plist' in the current working directory
         # ignoring any in 'build', or 'test' folders
-        return Dir.glob("./{ios/,}*/Info.plist").reject{|path| path =~ /build|test/i }.first
+        return Dir.glob("./{ios/,}*/Info.plist").reject{|path| path =~ /build|test/i }.sort.first
       end
 
       def self.options_from_info_plist file_path


### PR DESCRIPTION
## Goal

This makes the plist that gets picked deterministic, e.g. different operating systems can return files in different orders

This is the reason for the tests failing on Ubuntu but passing on macOS