### PR TITLE
Allow metadata in Fastlane send_build_to_bugsnag reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## TBD
+
+## Bug fixes
+* Enable fastlane to report custom metadata when using `send_build_to_bugsnag` action.
+  [#75](https://github.com/bugsnag/bugsnag-dsym-upload/pull/75)
+
 ## 2.2.1 (19-01-2022)
 
 ### Bug fixes

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -38,6 +38,9 @@ module Fastlane
         payload[:sourceControl][:repository] = params[:repository] if params[:repository]
         payload[:sourceControl][:provider] = params[:provider] if params[:provider]
 
+        # If provided apply metadata to payload.
+        payload[:metadata] = params[:metadata]
+
         payload.reject! {|k,v| v == nil || (v.is_a?(Hash) && v.empty?)}
 
         if payload[:apiKey].nil? || !payload[:apiKey].is_a?(String)
@@ -167,7 +170,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :endpoint,
                                        description: "Bugsnag deployment endpoint",
                                        optional: true,
-                                       default_value: "https://build.bugsnag.com")
+                                       default_value: "https://build.bugsnag.com"),
+          FastlaneCore::ConfigItem.new(key: :metadata,
+                                       description: "Metadata",
+                                       optional:true,
+                                       type: Object, 
+                                       default_value: nil)
         ]
       end
 
@@ -319,7 +327,7 @@ module Fastlane
           nil
         end
       end
-
+      
       def self.send_notification(url, body)
         require "net/http"
         uri = URI.parse(url)

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -121,5 +121,41 @@ describe BuildAction do
         end
       end
     end
+
+    context 'metadata added to payload' do
+      it "single key:value pair added" do
+        expect(BuildAction).to receive(:send_notification) do |url, body|
+          payload = ::JSON.load(body)
+          expect(payload['appVersion']).to eq '4.0-project'
+          expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
+          expect(payload['metadata']).to eq '"test1": "First test"'
+        end
+
+        Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+          run_with({
+            app_version: '4.0-project',
+            api_key: '12345678901234567890123456789DDD',
+            metadata: '"test1": "First test"'
+          })
+        end
+      end
+      
+      it "multiple key:value pairs added" do
+        expect(BuildAction).to receive(:send_notification) do |url, body|
+          payload = ::JSON.load(body)
+          expect(payload['appVersion']).to eq '4.0-project'
+          expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
+          expect(payload['metadata']).to eq '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+        end
+
+        Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+          run_with({
+            app_version: '4.0-project',
+            api_key: '12345678901234567890123456789DDD',
+            metadata: '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+          })
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Goal

This update makes it possible to report metadata as part of the Fastlane `send_build_to_bugsnag` function. In Fastlane it was not previously possible to do this, where it was with other build reporting methods. 

## Design

The changes made add a new config item, and add the provided metadata to the payload.

## Changeset

Addition of new config item and metadata payload. Bumped version number. 

## Testing

Tested in my local development environment using custom endpoints. When provided, metadata will be added to the reported release. 