### PR TITLE
Starting to add e2e tests for fastlane build reporter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,3 +4,10 @@ steps:
       docker-compose#v3.7.0:
         run: license_finder
     command: /bin/bash -lc '/scan/scripts/license_finder.sh'
+
+  - name: 'Run e2e tests'
+    agents:
+      queue: macos-12-arm
+    commands: 
+      - bundle install
+      - make test_features

--- a/features/fastlane_build_report.feature
+++ b/features/fastlane_build_report.feature
@@ -1,0 +1,146 @@
+Feature: Reporting build to Bugsnag using Fastlane
+
+    Scenario: Report basic build 
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890AAAAAA"
+        And the field "appVersion" for multipart request 0 equals "1.0.0"
+        Then the build exit status should be 0
+
+    Scenario: Report with appVersionCode (Android only)
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane android_version_code to "1234"
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 is not null
+        And the field "appVersion" for multipart request 0 is not null
+        And the field "appVersionCode" for multipart request 0 equals "1234"
+        Then the build exit status should be 0
+
+    Scenario: Report with appBundleVersion (IOS only)
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane ios_bundle_version to "1.2.3"
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 is not null
+        And the field "appVersion" for multipart request 0 is not null
+        And the field "appBundleVersion" for multipart request 0 equals "1.2.3"
+        Then the build exit status should be 0
+
+    Scenario: Report with releaseStage 
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane release_stage to "Production"
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 is not null
+        And the field "appVersion" for multipart request 0 is not null
+        And the field "releaseStage" for multipart request 0 equals "Production"
+        Then the build exit status should be 0
+
+    Scenario: Report with builderName
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane builder_name to "Bug Snag"
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 is not null
+        And the field "appVersion" for multipart request 0 is not null
+        And the field "builderName" for multipart request 0 equals "Bug Snag"
+        Then the build exit status should be 0
+
+    Scenario: Report with source control
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane repository to "www.github.com/a_repo/"
+        And I set fastlane revision to "12345"
+        And I set fastlane provider to "github"
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "sourceControl" for multipart request 0 is not null
+        Then the build exit status should be 0
+
+    Scenario: Report with single metadata
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane metadata to '"test1" : "First test"'
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 is not null
+        And the field "appVersion" for multipart request 0 is not null
+        And the field "metadata" for multipart request 0 is not null
+        Then the build exit status should be 0
+
+    Scenario: Report with multiple metadata
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane metadata to '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+        And I run lane "send_build"
+        Then I should receive 1 request
+        And the field "apiKey" for multipart request 0 is not null
+        And the field "appVersion" for multipart request 0 is not null
+        And the field "metadata" for multipart request 0 is not null
+        Then the build exit status should be 0
+
+    Scenario: Report with all params (Android)
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"
+        And I set fastlane android_version_code to "1234"
+        And I set fastlane release_stage to "Production"
+        And I set fastlane builder_name to "Bug Snag"
+        And I set fastlane repository to "www.github.com/a_repo/"
+        And I set fastlane revision to "12345"
+        And I set fastlane provider to "github"
+        And I set fastlane metadata to '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+        And I run lane "send_build"
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890AAAAAA"
+        And the field "appVersion" for multipart request 0 equals "1.0.0"
+        And the field "appVersionCode" for multipart request 0 equals "1234"
+        And the field "releaseStage" for multipart request 0 equals "Production"
+        And the field "builderName" for multipart request 0 equals "Bug Snag"
+        And the field "sourceControl" for multipart request 0 is not null
+        And the field "metadata" for multipart request 0 is not null
+        Then the build exit status should be 0
+
+    Scenario: Report with all params (IOS)
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I set fastlane app_version to "1.0.0"       
+        And I set fastlane ios_bundle_version to "1.2.3"
+        And I set fastlane release_stage to "Production"
+        And I set fastlane builder_name to "Bug Snag"
+        And I set fastlane repository to "www.github.com/a_repo/"
+        And I set fastlane revision to "12345"
+        And I set fastlane provider to "github"
+        And I set fastlane metadata to '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+        And I run lane "send_build"
+        And the field "apiKey" for multipart request 0 equals "1234567890ABCDEF1234567890AAAAAA"
+        And the field "appVersion" for multipart request 0 equals "1.0.0"
+        And the field "appBundleVersion" for multipart request 0 equals "1.2.3"
+        And the field "releaseStage" for multipart request 0 equals "Production"
+        And the field "builderName" for multipart request 0 equals "Bug Snag"
+        And the field "sourceControl" for multipart request 0 is not null
+        And the field "metadata" for multipart request 0 is not null
+        Then the build exit status should be 0
+
+    Scenario: Throw failure if no API key
+        When I set fastlane api_key to nil
+        And I set fastlane app_version to "1.0.0"
+        And I run lane "send_build"
+        Then I should receive 0 requests
+        Then the exit status should be 1
+
+    Scenario: Throw failure if no app version
+        When I set fastlane api_key to "1234567890ABCDEF1234567890AAAAAA"
+        And I run lane "send_build"
+        Then I should receive 0 requests
+        Then the exit status should be 1
+
+    Scenario: Throw failure if no params
+        When I set no parameters
+        And I run lane "send_build"
+        Then I should receive 0 requests
+        Then the exit status should be 1

--- a/features/fixtures/fl-project/fastlane/Fastfile
+++ b/features/fixtures/fl-project/fastlane/Fastfile
@@ -5,10 +5,21 @@ api_key = ENV['BUGSNAG_API_KEY']
 config_file = ENV['BUGSNAG_CONFIG_FILE']
 ignore_empty_dsym = ENV['BUGSNAG_IGNORE_EMPTY_DSYM']
 ignore_missing_dwarf = ENV['BUGSNAG_IGNORE_MISSING_DWARF']
+# Build reporting exclusive
+app_version = ENV['BUGSNAG_APP_VERSION']
+android_version_code = ENV['BUGSNAG_ANDROID_VERSION_CODE']
+ios_bundle_version = ENV['BUGSNAG_IOS_BUNDLE_VERSION']
+release_stage = ENV["BUGSNAG_RELEASE_STAGE"]
+builder_name = ENV["BUGSNAG_BUILDER_NAME"]
+repository = ENV["BUGSNAG_REPOSITORY"]
+revision = ENV["BUGSNAG_REVISION"]
+provider = ENV["BUGSNAG_PROVIDER"]
+metadata = ENV['BUGSNAG_BUILD_METADATA']
 
 platform :ios do
+  # Report used for all build tests
   lane :send_build do
-    send_build_to_bugsnag(upload_url: endpoint, api_key: api_key)
+    send_build_to_bugsnag(endpoint: endpoint, api_key: api_key, app_version: app_version, android_version_code: android_version_code, ios_bundle_version: ios_bundle_version, release_stage: release_stage, builder: builder_name, repository: repository, revision: revision, provider: provider, metadata: metadata)
   end
 
   lane :upload_symbols do
@@ -40,7 +51,6 @@ platform :ios do
     Actions.lane_context[SharedValues::DSYM_PATHS] = ["../bugsnag-example 14-05-2021,,, 11.27éøœåñü#.xcarchive/dSYMs"]
     upload_symbols_to_bugsnag(upload_url: endpoint, api_key: api_key, ignore_empty_dsym: true, ignore_missing_dwarf: true)
   end
-
 end
 
 

--- a/features/steps/fastlane_build_report_steps.rb
+++ b/features/steps/fastlane_build_report_steps.rb
@@ -1,0 +1,77 @@
+Given "fastlane is installed" do
+    $fastlane_installed ||= begin
+      step('I run the script "features/scripts/install-fastlane.sh" synchronously')
+      true
+    end
+  end
+
+  # Default request values. Values not set in scenario remain as nil.
+  @api_key = nil
+  @app_version = nil
+  @android_version_code = nil
+  @ios_bundle_version = nil
+  @release_stage = nil
+  @builder_name = nil
+  @repository = nil
+  @revision = nil
+  @provider = nil
+  @metadata = nil
+
+  # Steps to set request parameters. If step not called in scenario param left as nil.
+  When ("I set fastlane api_key to {string}") do |api_key|
+    @api_key = api_key
+  end
+
+  And ("I set fastlane app_version to {string}") do |app_version|
+    @app_version = app_version
+  end
+
+  And ("I set fastlane android_version_code to {string}") do |android_version_code|
+    @android_version_code = android_version_code
+  end
+
+  And ("I set fastlane ios_bundle_version to {string}") do |ios_bundle_version|
+    @ios_bundle_version = ios_bundle_version
+  end
+
+  And ("I set fastlane release_stage to {string}") do |release_stage|
+    @release_stage = release_stage
+  end
+
+  And ("I set fastlane builder_name to {string}") do |builder_name|
+    @builder_name = builder_name
+  end
+
+  And ("I set fastlane repository to {string}") do |repository|
+    @repository = repository
+  end
+
+  And ("I set fastlane revision to {string}") do |revision|
+    @revision = revision
+  end
+
+  And ("I set fastlane provider to {string}") do |provider|
+    @provider = provider
+  end
+
+  And ("I set fastlane metadata to {string}") do |metadata|
+    @metadata = metadata
+  end
+
+  # Runs lane, passing all params with non active params passed as nil
+  And ("I run lane {string}") do |lane|
+    fastlane_report_build(lane, @api_key, @app_version, @android_version_code, @ios_bundle_version, @release_stage, @builder_name, @repository, @revision, @provider, @metadata)
+  end
+
+  Then ("the build exit status should be {int}") do |int|
+    assert_equal(int, $?.exitstatus)
+  end
+
+  # Steps to allow failures to be tested.
+  When ("I set fastlane api_key to nil") do 
+    # Mothing happens here
+  end
+
+  When ("I set no parameters") do 
+    # Nothing happens here
+  end 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,3 +34,34 @@ def fastlane_upload_symbols(lane, dsym_path=nil, api_key=nil, config_file=nil, i
     end
   end
 end
+
+# Non active params automatically set to nil. No need to set manually here.
+def fastlane_report_build(lane, api_key, app_version, android_version_code, ios_bundle_version, release_stage, builder_name, repository, revision, provider, metadata)
+  api_key_env = "BUGSNAG_API_KEY='#{api_key}'" unless api_key.nil?
+  app_version_env = "BUGSNAG_APP_VERSION='#{app_version}'" unless app_version.nil?
+  android_version_code_env = "BUGSNAG_ANDROID_VERSION_CODE='#{android_version_code}'" unless android_version_code.nil?
+  ios_bundle_version_env = "BUGSNAG_IOS_BUNDLE_VERSION='#{ios_bundle_version}'" unless ios_bundle_version.nil?
+  release_stage_env = "BUGSNAG_RELEASE_STAGE='#{release_stage}'" unless release_stage.nil?
+  builder_name_env = "BUGSNAG_BUILDER_NAME='#{builder_name}'" unless builder_name.nil?
+  repository_env = "BUGSNAG_REPOSITORY='#{repository}'" unless repository.nil?
+  revision_env = "BUGSNAG_REVISION='#{revision}'" unless revision.nil?
+  provider_env = "BUGSNAG_PROVIDER='#{provider}'" unless provider.nil?
+  metadata_env = "BUGSNAG_BUILD_METADATA='#{metadata}'" unless app_version.nil?
+
+  Bundler.with_unbundled_env do
+    Dir.chdir 'features/fixtures/fl-project' do
+      `BUGSNAG_ENDPOINT='http://localhost:#{MOCK_API_PORT}'\
+      #{api_key_env} \
+      #{app_version_env} \
+      #{android_version_code_env} \
+      #{ios_bundle_version_env} \
+      #{release_stage_env} \
+      #{builder_name_env} \
+      #{repository_env} \
+      #{revision_env} \
+      #{provider_env} \
+      #{metadata_env} \
+      bundle exec fastlane #{lane}`
+    end
+  end
+end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -38,6 +38,9 @@ module Fastlane
         payload[:sourceControl][:repository] = params[:repository] if params[:repository]
         payload[:sourceControl][:provider] = params[:provider] if params[:provider]
 
+        # If provided apply metadata to payload.
+        payload[:metadata] = params[:metadata]
+
         payload.reject! {|k,v| v == nil || (v.is_a?(Hash) && v.empty?)}
 
         if payload[:apiKey].nil? || !payload[:apiKey].is_a?(String)
@@ -167,7 +170,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :endpoint,
                                        description: "Bugsnag deployment endpoint",
                                        optional: true,
-                                       default_value: "https://build.bugsnag.com")
+                                       default_value: "https://build.bugsnag.com"),
+          FastlaneCore::ConfigItem.new(key: :metadata,
+                                       description: "Metadata",
+                                       optional:true,
+                                       type: Object, 
+                                       default_value: nil)
         ]
       end
 


### PR DESCRIPTION
## Goal

There are currently no or few e2e tests for Fastlanes `send_build_to_bugsnag` function. This PR intends to rectify that making it easier to test future changes to the tool.

## Design

Cucumber was used for e2e tests, with most changes being inspired by similar e2e tests for Fastlane dsym upload functions.

## Changeset

`fastlane_build_report.feature` file added to house all build reporting scenarios. Modifications made to other files to enable test functionality. 

## Testing

Step added to the Buildkite pipeline to run the e2e tests.