### PR TITLE
Moving default_info_plist_path to shared class

### DIFF
--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/find_info_plist_path.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/find_info_plist_path.rb
@@ -1,0 +1,7 @@
+class FindInfoPlist
+    def self.default_info_plist_path
+        # Find first 'Info.plist' in the current working directory
+        # ignoring any in 'build', or 'test' folders
+        return Dir.glob("./{ios/,}*/Info.plist").reject{|path| path =~ /build|test/i }.sort.first
+    end
+end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -1,5 +1,6 @@
 require "xmlsimple"
 require "json"
+require_relative "find_info_plist_path"
 
 module Fastlane
   module Actions
@@ -196,7 +197,7 @@ module Fastlane
         when nil
           if file_path = default_android_manifest_path
             return file_path
-          elsif file_path = default_info_plist_path
+          elsif file_path = FindInfoPlist.default_info_plist_path
             return file_path
           end
         when :android
@@ -204,7 +205,7 @@ module Fastlane
             return file_path
           end
         else
-          if file_path = default_info_plist_path
+          if file_path = FindInfoPlist.default_info_plist_path
             return file_path
           end
         end
@@ -222,10 +223,6 @@ module Fastlane
         else
           UI.user_error("File type of '#{config_file}' was not recognised. This should be .xml for Android and .plist for Cococa")
         end
-      end
-
-      def self.default_info_plist_path
-        Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }.sort.first
       end
 
       def self.load_options_from_plist file_path

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -1,3 +1,5 @@
+require_relative "find_info_plist_path"
+
 module Fastlane
   module Actions
     class UploadSymbolsToBugsnagAction < Action
@@ -131,17 +133,11 @@ module Fastlane
                                        env_name: "BUGSNAG_CONFIG_FILE",
                                        description: "Info.plist location",
                                        optional: true,
-                                       default_value: default_info_plist_path)
+                                       default_value: FindInfoPlist.default_info_plist_path)
         ]
       end
 
       private
-
-      def self.default_info_plist_path
-        # Find first 'Info.plist' in the current working directory
-        # ignoring any in 'build', or 'test' folders
-        return Dir.glob("./{ios/,}*/Info.plist").reject{|path| path =~ /build|test/i }.sort.first
-      end
 
       def self.options_from_info_plist file_path
         plist_getter = Fastlane::Actions::GetInfoPlistValueAction


### PR DESCRIPTION
Internal note (will be removed before release): https://smartbear.atlassian.net/browse/PLAT-4743 

## Goal

Aims to put `default_info_plist_path` method into shared class to reduce copy pasted code. 

## Design

I decided that the existing method should be moved to a new class file. Currently the new class file will be located in the same directory as `send_build_to_bugsnag.rb` and `upload_symbols_to_bugsnag.rb`

## Changeset

New file `find_info_plist_path.rb` added to contain `FindInfoPlist` class. Old copy pasted `default_info_plist_path` methods removed from `end_build...` and `upload_dsym...` files. 

## Testing

Unit and e2e tests run locally. All pass fine. Possibly worth adding new unit test for new class.