### PR TITLE
Bumping macOS version for GitHub tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.5']
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Tests likely started failing as Github bumped their support for macOS versions. 

This PR bumps the macOS version used for GitHub tests. from `10.15` to `11`