### PR TITLE
Use the Bugsnag CLI to send build information

### DIFF
--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
@@ -14,8 +14,10 @@ class BugsnagCli
       if bugsnag_cli_version < bundled_bugsnag_cli_version
         FastlaneCore::UI.warning("The installed bugsnag-cli at #{bugsnag_cli_path} is outdated (#{bugsnag_cli_version}). The current bundled version is: #{bundled_bugsnag_cli_version}. It is recommended that you either update your installed version or use the bundled version.")
       end
+      FastlaneCore::UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
       bugsnag_cli_path
     else
+      FastlaneCore::UI.verbose("Using bundled bugsnag-cli from path: #{bundled_bugsnag_cli_path}")
       bundled_bugsnag_cli_path
     end
   end
@@ -48,4 +50,55 @@ class BugsnagCli
   def self.bin_folder(filename)
     File.expand_path("../../../../../bin/#{filename}", File.dirname(__FILE__))
   end
+
+  def self.create_build_args(api_key, version_name, version_code, bundle_version, release_stage, builder, revision, repository, provider, auto_assign_release, metadata, retries, timeout, endpoint)
+    args = []
+    args += ["--api-key", api_key] unless api_key.nil?
+    args += ["--version-name", version_name] unless version_name.nil?
+    args += ["--version-code", version_code] unless version_code.nil?
+    args += ["--bundle-version", bundle_version] unless bundle_version.nil?
+    args += ["--release-stage", release_stage] unless release_stage.nil?
+    args += ["--builder-name", builder] unless builder.nil?
+    args += ["--revision", revision] unless revision.nil?
+    args += ["--repository", repository] unless repository.nil?
+    args += ["--provider", provider] unless provider.nil?
+    args += ["--auto-assign-release"] if auto_assign_release
+    unless metadata.nil?
+      if metadata.is_a?(String)
+        #
+        args += ["--metadata", metadata]
+      elsif metadata.is_a?(Hash)
+        formatted_metadata = metadata.map { |k, v| %Q{"#{k}"="#{v}"} }.join(",")
+        args += ["--metadata", formatted_metadata]
+      end
+    end
+    args += ["--retries", retries] unless retries.nil?
+    args += ["--timeout", timeout] unless timeout.nil?
+    args += ["--build-api-root-url", endpoint] unless endpoint.nil?
+    args += ["--verbose"] if FastlaneCore::Globals.verbose?
+    args
+  end
+
+  def self.upload_args dir, upload_url, project_root, api_key, ignore_missing_dwarf, ignore_empty_dsym, dryrun, log_level, port, retries, timeout, configuration, scheme, plist, xcode_project
+    args = []
+    args += ["--verbose"] if FastlaneCore::Globals.verbose?
+    args += ["--ignore-missing-dwarf"] if ignore_missing_dwarf
+    args += ["--ignore-empty-dsym"] if ignore_empty_dsym
+    args += ["--api-key", api_key] unless api_key.nil?
+    args += ["--upload-api-root-url", upload_url] unless upload_url.nil?
+    args += ["--project-root", project_root] unless project_root.nil?
+    args += ["--dry-run"] if dryrun
+    args += ["--log-level", log_level] unless log_level.nil?
+    args += ["--port", port] unless port.nil?
+    args += ["--retries", retries] unless retries.nil?
+    args += ["--timeout", timeout] unless timeout.nil?
+    args += ["--configuration", configuration] unless configuration.nil?
+    args += ["--scheme", scheme] unless scheme.nil?
+    args += ["--plist", plist] unless plist.nil?
+    args += ["--xcode-project", xcode_project] unless xcode_project.nil?
+    args << dir
+    args
+  end
 end
+
+

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
@@ -99,6 +99,18 @@ class BugsnagCli
     args << dir
     args
   end
+
+  def self.upload_dsym cli_path, args
+    bugsnag_cli_command = "#{cli_path} upload dsym #{args.join(' ')}"
+    FastlaneCore::UI.verbose("Running command: #{bugsnag_cli_command}")
+    Kernel.system(bugsnag_cli_command)
+  end
+
+  def self.create_build cli_path, args
+    bugsnag_cli_command = "#{cli_path} create-build #{args.join(' ')}"
+    FastlaneCore::UI.verbose("Running command: #{bugsnag_cli_command}")
+    Kernel.system(bugsnag_cli_command)
+  end
 end
 
 

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
@@ -1,8 +1,26 @@
 require 'os'
 require 'rbconfig'
 
-class BundledCli
-  def self.get_path
+class BugsnagCli
+  def self.get_bugsnag_cli_path(params)
+    bundled_bugsnag_cli_path = self.get_bundled_path
+    bundled_bugsnag_cli_version = Gem::Version.new(`#{bundled_bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
+
+    if params[:bugsnag_cli_path]
+      bugsnag_cli_path = params[:bugsnag_cli_path] || bundled_bugsnag_cli_path
+
+      bugsnag_cli_version = Gem::Version.new(`#{bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
+
+      if bugsnag_cli_version < bundled_bugsnag_cli_version
+        UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
+      end
+      bugsnag_cli_path
+    else
+      bundled_bugsnag_cli_path
+    end
+  end
+
+  def self.get_bundled_path
     host_cpu = RbConfig::CONFIG['host_cpu']
     if OS.mac?
       if host_cpu =~ /arm|aarch64/

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
@@ -12,7 +12,7 @@ class BugsnagCli
       bugsnag_cli_version = Gem::Version.new(`#{bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
 
       if bugsnag_cli_version < bundled_bugsnag_cli_version
-        UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
+        FastlaneCore::UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
       end
       bugsnag_cli_path
     else

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bugsnag_cli.rb
@@ -12,7 +12,7 @@ class BugsnagCli
       bugsnag_cli_version = Gem::Version.new(`#{bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
 
       if bugsnag_cli_version < bundled_bugsnag_cli_version
-        FastlaneCore::UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
+        FastlaneCore::UI.warning("The installed bugsnag-cli at #{bugsnag_cli_path} is outdated (#{bugsnag_cli_version}). The current bundled version is: #{bundled_bugsnag_cli_version}. It is recommended that you either update your installed version or use the bundled version.")
       end
       bugsnag_cli_path
     else

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bundled_cli_path.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bundled_cli_path.rb
@@ -19,11 +19,10 @@ class BundledCli
     else
       if host_cpu =~ /arm|aarch64/
         self.bin_folder('arm64-linux-bugsnag-cli')
-      else if OS.bits == 64
-             self.bin_folder('x86_64-linux-bugsnag-cli')
-           else
-             self.bin_folder('i386-linux-bugsnag-cli')
-           end
+      elsif OS.bits == 64
+        self.bin_folder('x86_64-linux-bugsnag-cli')
+      else
+        self.bin_folder('i386-linux-bugsnag-cli')
       end
     end
   end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bundled_cli_path.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/bundled_cli_path.rb
@@ -1,0 +1,34 @@
+require 'os'
+require 'rbconfig'
+
+class BundledCli
+  def self.get_path
+    host_cpu = RbConfig::CONFIG['host_cpu']
+    if OS.mac?
+      if host_cpu =~ /arm|aarch64/
+        self.bin_folder('arm64-macos-bugsnag-cli')
+      else
+        self.bin_folder('x86_64-macos-bugsnag-cli')
+      end
+    elsif OS.windows?
+      if OS.bits == 64
+        self.bin_folder('x86_64-windows-bugsnag-cli.exe')
+      else
+        self.bin_folder('i386-windows-bugsnag-cli.exe')
+      end
+    else
+      if host_cpu =~ /arm|aarch64/
+        self.bin_folder('arm64-linux-bugsnag-cli')
+      else if OS.bits == 64
+             self.bin_folder('x86_64-linux-bugsnag-cli')
+           else
+             self.bin_folder('i386-linux-bugsnag-cli')
+           end
+      end
+    end
+  end
+
+  def self.bin_folder(filename)
+    File.expand_path("../../../../../bin/#{filename}", File.dirname(__FILE__))
+  end
+end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -8,63 +8,91 @@ module Fastlane
     class SendBuildToBugsnagAction < Action
       def self.run(params)
         bugsnag_cli_path = BugsnagCli.get_bugsnag_cli_path(params)
-        UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
-
-        payload = {}
+        verbose = UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
 
         # If a configuration file was found or was specified, load in the options:
+        config_options = {}
         if params[:config_file]
           UI.message("Loading build information from #{params[:config_file]}")
           config_options = load_config_file_options(params[:config_file])
-
-          # for each of the config options, if it's not been overriden by any
-          # input to the lane, write it to the payload:
-          payload[:apiKey] = params[:api_key] || config_options[:apiKey]
-          payload[:versionName] = params[:app_version] || config_options[:appVersion]
-          payload[:versionCode] = params[:android_version_code] || config_options[:appVersionCode]
-          payload[:bundleVersion] = params[:ios_bundle_version] || config_options[:appBundleVersion]
-          payload[:releaseStage] = params[:release_stage] || config_options[:releaseStage] || "production"
-        else
-          # No configuration file was found or specified, use the input parameters:
-          payload[:apiKey] = params[:api_key]
-          payload[:versionName] = params[:app_version]
-          payload[:versionCode] = params[:android_version_code]
-          payload[:bundleVersion] = params[:ios_bundle_version]
-          payload[:releaseStage] = params[:release_stage] || "production"
         end
 
-        # If builder, or source control information has been provided into
-        # Fastlane, apply it to the payload here.
-        payload[:builderName] = params[:builder] if params[:builder]
-        payload[:revision] = params[:revision] if params[:revision]
-        payload[:repository] = params[:repository] if params[:repository]
-        payload[:provider] = params[:provider] if params[:provider]
+        api_key = params[:api_key] || config_options[:apiKey] unless (params[:api_key].nil? && config_options[:apiKey].nil?)
+        version_name = params[:app_version] || config_options[:appVersion] unless (params[:app_version].nil? && config_options[:appVersion].nil?)
+        version_code = params[:android_version_code] || config_options[:appVersionCode] unless (params[:android_version_code].nil? && config_options[:appVersionCode].nil?)
+        bundle_version = params[:ios_bundle_version] || config_options[:appBundleVersion] unless (params[:ios_bundle_version].nil? && config_options[:appBundleVersion].nil?)
+        release_stage = params[:release_stage] || config_options[:releaseStage] || "production" unless (params[:release_stage].nil? && config_options[:releaseStage].nil?)
+        builder = params[:builder] unless params[:builder].nil?
+        revision = params[:revision] unless params[:revision].nil?
+        repository = params[:repository] unless params[:repository].nil?
+        provider = params[:provider] unless params[:provider].nil?
+        auto_assign_release = params[:auto_assign_release] unless params[:auto_assign_release].nil?
+        metadata = params[:metadata] unless params[:metadata].nil?
+        retries = params[:retries] unless params[:retries].nil?
+        timeout = params[:timeout] unless params[:timeout].nil?
+        endpoint = params[:endpoint] unless params[:endpoint].nil?
 
-        payload[:autoAssignRelease] = params[:auto_assign_release] if params[:auto_assign_release]
 
-        # If provided apply metadata to payload.
-        payload[:metadata] = params[:metadata]
-
-        payload[:retries] = params[:retries] if params[:retries]
-        payload[:timeout] = params[:timeout] if params[:timeout]
-        payload[:buildApiRootUrl] = params[:endpoint] if params[:endpoint]
-
-        payload.reject! {|k,v| v == nil || (v.is_a?(Hash) && v.empty?)}
-
-        if payload[:apiKey].nil? || !payload[:apiKey].is_a?(String)
+        if api_key.nil? || !api_key.is_a?(String)
           UI.user_error! missing_api_key_message(params)
         end
-        if payload[:versionName].nil?
+        if version_name.nil?
           UI.user_error! missing_app_version_message(params)
         end
 
-        # If verbose flag is enabled (`--verbose`), display the payload debug info
-        UI.verbose("Sending build to Bugsnag with payload:")
-        payload.each do |param|
-          UI.verbose("  #{param[0].to_s.rjust(18)}: #{param[1]}")
+        args = create_build_args(
+          api_key,
+          version_name,
+          version_code,
+          bundle_version,
+          release_stage,
+          builder,
+          revision,
+          repository,
+          provider,
+          auto_assign_release,
+          metadata,
+          retries,
+          timeout,
+          endpoint,
+          verbose
+        )
+        bugsnag_cli_command = "#{bugsnag_cli_path} create-build #{args.join(' ')}"
+        UI.verbose("Running command: #{bugsnag_cli_command}")
+        success = Kernel.system(bugsnag_cli_command)
+        if success
+          UI.success("Build successfully sent to Bugsnag")
+        else
+          UI.user_error!("Failed to send build to Bugsnag.")
         end
+      end
 
-        send_notification(bugsnag_cli_path, ::JSON.dump(payload))
+      def self.create_build_args(api_key, version_name, version_code, bundle_version, release_stage, builder, revision, repository, provider, auto_assign_release, metadata, retries, timeout, endpoint, verbose)
+        args = []
+        args += ["--api-key", api_key] unless api_key.nil?
+        args += ["--version-name", version_name] unless version_name.nil?
+        args += ["--version-code", version_code] unless version_code.nil?
+        args += ["--bundle-version", bundle_version] unless bundle_version.nil?
+        args += ["--release-stage", release_stage] unless release_stage.nil?
+        args += ["--builder-name", builder] unless builder.nil?
+        args += ["--revision", revision] unless revision.nil?
+        args += ["--repository", repository] unless repository.nil?
+        args += ["--provider", provider] unless provider.nil?
+        args += ["--auto-assign-release"] if auto_assign_release
+        unless metadata.nil?
+          if metadata.is_a?(String)
+            #
+            args += ["--metadata", metadata]
+          elsif metadata.is_a?(Hash)
+            formatted_metadata = metadata.map { |k, v| %Q{"#{k}"="#{v}"} }.join(",")
+            args += ["--metadata", formatted_metadata]
+          end
+        end
+        args += ["--retries", retries] unless retries.nil?
+        args += ["--timeout", timeout] unless timeout.nil?
+        args += ["--build-api-root-url", endpoint] unless endpoint.nil?
+        args += ["--verbose"] if verbose
+        args
       end
 
       def self.missing_api_key_message(params)
@@ -182,8 +210,8 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :endpoint,
                                        description: "Bugsnag deployment endpoint",
-                                       optional: true,
-                                       default_value: "https://build.bugsnag.com"),
+                                       default_value: nil,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :metadata,
                                        description: "Metadata",
                                        optional:true,
@@ -221,7 +249,8 @@ module Fastlane
             git_options[:repository] = origin.url
             git_options[:revision] = repo.revparse("HEAD")
           end
-        rescue
+        rescue => e
+          UI.verbose("Could not load git options: #{e.message}")
         end
         return git_options
       end
@@ -342,46 +371,6 @@ module Fastlane
           output[hash["android:name"]] = hash["android:value"]
         end
         output
-      end
-
-      def self.parse_response_body(response)
-        begin
-          JSON.load(response.body)
-        rescue
-          nil
-        end
-      end
-
-      def self.to_kebab_case(str)
-      str.gsub(/([a-z])([A-Z])/, '\1-\2').downcase
-      end
-
-      def self.json_to_cli_args(json_payload)
-        data = JSON.parse(json_payload)
-
-        data.map do |k, v|
-          key = to_kebab_case(k)
-          if v.is_a?(Hash)
-            # Convert nested hash into key=value pairs joined by commas
-            nested = v.map { |nk, nv| "#{to_kebab_case(nk)}=#{nv}" }.join(",")
-            "--#{key}=#{nested}"
-          else
-            "--#{key}=#{v}"
-          end
-        end.join(" ")
-      end
-
-      def self.send_notification(cli_path, body)
-        args = self.json_to_cli_args(body)
-        bugsnag_cli_command = "#{cli_path} create-build #{args}"
-
-        UI.verbose("Running command: #{bugsnag_cli_command}")
-        success = Kernel.system(bugsnag_cli_command)
-        if success
-          UI.success("Build successfully sent to Bugsnag")
-        else
-          UI.user_error!("Failed to send build to Bugsnag.")
-        end
       end
     end
   end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -8,7 +8,6 @@ module Fastlane
     class SendBuildToBugsnagAction < Action
       def self.run(params)
         bugsnag_cli_path = BugsnagCli.get_bugsnag_cli_path(params)
-        verbose = UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
 
         # If a configuration file was found or was specified, load in the options:
         config_options = {}
@@ -40,7 +39,7 @@ module Fastlane
           UI.user_error! missing_app_version_message(params)
         end
 
-        args = create_build_args(
+        args = BugsnagCli.create_build_args(
           api_key,
           version_name,
           version_code,
@@ -54,8 +53,7 @@ module Fastlane
           metadata,
           retries,
           timeout,
-          endpoint,
-          verbose
+          endpoint
         )
         bugsnag_cli_command = "#{bugsnag_cli_path} create-build #{args.join(' ')}"
         UI.verbose("Running command: #{bugsnag_cli_command}")
@@ -65,34 +63,6 @@ module Fastlane
         else
           UI.user_error!("Failed to send build to Bugsnag.")
         end
-      end
-
-      def self.create_build_args(api_key, version_name, version_code, bundle_version, release_stage, builder, revision, repository, provider, auto_assign_release, metadata, retries, timeout, endpoint, verbose)
-        args = []
-        args += ["--api-key", api_key] unless api_key.nil?
-        args += ["--version-name", version_name] unless version_name.nil?
-        args += ["--version-code", version_code] unless version_code.nil?
-        args += ["--bundle-version", bundle_version] unless bundle_version.nil?
-        args += ["--release-stage", release_stage] unless release_stage.nil?
-        args += ["--builder-name", builder] unless builder.nil?
-        args += ["--revision", revision] unless revision.nil?
-        args += ["--repository", repository] unless repository.nil?
-        args += ["--provider", provider] unless provider.nil?
-        args += ["--auto-assign-release"] if auto_assign_release
-        unless metadata.nil?
-          if metadata.is_a?(String)
-            #
-            args += ["--metadata", metadata]
-          elsif metadata.is_a?(Hash)
-            formatted_metadata = metadata.map { |k, v| %Q{"#{k}"="#{v}"} }.join(",")
-            args += ["--metadata", formatted_metadata]
-          end
-        end
-        args += ["--retries", retries] unless retries.nil?
-        args += ["--timeout", timeout] unless timeout.nil?
-        args += ["--build-api-root-url", endpoint] unless endpoint.nil?
-        args += ["--verbose"] if verbose
-        args
       end
 
       def self.missing_api_key_message(params)

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -1,15 +1,34 @@
 require "xmlsimple"
 require "json"
 require_relative "find_info_plist_path"
+require_relative "bundled_cli_path"
 
 module Fastlane
   module Actions
     class SendBuildToBugsnagAction < Action
+      def self.get_bugsnag_cli_path(params)
+        bundled_bugsnag_cli_path = BundledCli.get_path
+        bundled_bugsnag_cli_version = Gem::Version.new(`#{bundled_bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
 
-      BUILD_TOOL = "bugsnag-fastlane-plugin"
+        if params[:bugsnag_cli_path]
+          bugsnag_cli_path = params[:bugsnag_cli_path] || bundled_bugsnag_cli_path
+
+          bugsnag_cli_version = Gem::Version.new(`#{bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
+
+          if bugsnag_cli_version < bundled_bugsnag_cli_version
+            UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
+          end
+          bugsnag_cli_path
+        else
+          bundled_bugsnag_cli_path
+        end
+      end
 
       def self.run(params)
-        payload = {buildTool: BUILD_TOOL, sourceControl: {}}
+        bugsnag_cli_path = get_bugsnag_cli_path(params)
+        UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
+
+        payload = {}
 
         # If a configuration file was found or was specified, load in the options:
         if params[:config_file]
@@ -19,35 +38,41 @@ module Fastlane
           # for each of the config options, if it's not been overriden by any
           # input to the lane, write it to the payload:
           payload[:apiKey] = params[:api_key] || config_options[:apiKey]
-          payload[:appVersion] = params[:app_version] || config_options[:appVersion]
-          payload[:appVersionCode] = params[:android_version_code] || config_options[:appVersionCode]
-          payload[:appBundleVersion] = params[:ios_bundle_version] || config_options[:appBundleVersion]
+          payload[:versionName] = params[:app_version] || config_options[:appVersion]
+          payload[:versionCode] = params[:android_version_code] || config_options[:appVersionCode]
+          payload[:bundleVersion] = params[:ios_bundle_version] || config_options[:appBundleVersion]
           payload[:releaseStage] = params[:release_stage] || config_options[:releaseStage] || "production"
         else
           # No configuration file was found or specified, use the input parameters:
           payload[:apiKey] = params[:api_key]
-          payload[:appVersion] = params[:app_version]
-          payload[:appVersionCode] = params[:android_version_code]
-          payload[:appBundleVersion] = params[:ios_bundle_version]
+          payload[:versionName] = params[:app_version]
+          payload[:versionCode] = params[:android_version_code]
+          payload[:bundleVersion] = params[:ios_bundle_version]
           payload[:releaseStage] = params[:release_stage] || "production"
         end
 
         # If builder, or source control information has been provided into
         # Fastlane, apply it to the payload here.
         payload[:builderName] = params[:builder] if params[:builder]
-        payload[:sourceControl][:revision] = params[:revision] if params[:revision]
-        payload[:sourceControl][:repository] = params[:repository] if params[:repository]
-        payload[:sourceControl][:provider] = params[:provider] if params[:provider]
+        payload[:revision] = params[:revision] if params[:revision]
+        payload[:repository] = params[:repository] if params[:repository]
+        payload[:provider] = params[:provider] if params[:provider]
+
+        payload[:autoAssignRelease] = params[:auto_assign_release] if params[:auto_assign_release]
 
         # If provided apply metadata to payload.
         payload[:metadata] = params[:metadata]
+
+        payload[:retries] = params[:retries] if params[:retries]
+        payload[:timeout] = params[:timeout] if params[:timeout]
+        payload[:buildApiRootUrl] = params[:endpoint] if params[:endpoint]
 
         payload.reject! {|k,v| v == nil || (v.is_a?(Hash) && v.empty?)}
 
         if payload[:apiKey].nil? || !payload[:apiKey].is_a?(String)
           UI.user_error! missing_api_key_message(params)
         end
-        if payload[:appVersion].nil?
+        if payload[:versionName].nil?
           UI.user_error! missing_app_version_message(params)
         end
 
@@ -57,7 +82,7 @@ module Fastlane
           UI.verbose("  #{param[0].to_s.rjust(18)}: #{param[1]}")
         end
 
-        send_notification(params[:endpoint], ::JSON.dump(payload))
+        send_notification(bugsnag_cli_path, ::JSON.dump(payload))
       end
 
       def self.missing_api_key_message(params)
@@ -146,6 +171,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :release_stage,
                                        description: "Release stage being built, i.e. staging, production",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :auto_assign_release,
+                                       description: "Whether to automatically associate this build with any new error events and sessions that are received for",
+                                       optional: true,
+                                       default_value: false,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :builder,
                                        description: "The name of the entity triggering the build",
                                        optional: true,
@@ -175,8 +205,23 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :metadata,
                                        description: "Metadata",
                                        optional:true,
-                                       type: Object, 
-                                       default_value: nil)
+                                       type: Object,
+                                       default_value: nil),
+          FastlaneCore::ConfigItem.new(key: :retries,
+                                       description: "The number of retry attempts before failing an upload request",
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       description: "The number of seconds to wait before failing an upload request",
+                                       optional: true,
+                                       is_string: false),
+          FastlaneCore::ConfigItem.new(key: :bugsnag_cli_path,
+                                       env_name: "BUGSNAG_CLI_PATH",
+                                       description: "Path to your bugsnag-cli",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error! "'#{value}' is not executable" unless FastlaneCore::Helper.executable?(value)
+                                       end)
         ]
       end
 
@@ -324,35 +369,36 @@ module Fastlane
           nil
         end
       end
-      
-      def self.send_notification(url, body)
-        require "net/http"
-        uri = URI.parse(url)
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.read_timeout = 15
-        http.open_timeout = 15
 
-        http.use_ssl = uri.scheme == "https"
+      def self.to_kebab_case(str)
+      str.gsub(/([a-z])([A-Z])/, '\1-\2').downcase
+      end
 
-        uri.path == "" ? "/" : uri.path
-        request = Net::HTTP::Post.new(uri, {"Content-Type" => "application/json"})
-        request.body = body
-        begin
-          response = http.request(request)
-        rescue => e
-          UI.user_error! "Failed to notify Bugsnag of a new build: #{e}"
-        end
-        if body = parse_response_body(response)
-          if body.has_key? "errors"
-            errors = body["errors"].map {|error| "\n  * #{error}"}.join
-            UI.user_error! "The following errors occurred while notifying Bugsnag:#{errors}.\n\nPlease update your lane config and retry."
-          elsif response.code != "200"
-            UI.user_error! "Failed to notify Bugsnag of a new build. Please retry. HTTP status code: #{response.code}"
+      def self.json_to_cli_args(json_payload)
+        data = JSON.parse(json_payload)
+
+        data.map do |k, v|
+          key = to_kebab_case(k)
+          if v.is_a?(Hash)
+            # Convert nested hash into key=value pairs joined by commas
+            nested = v.map { |nk, nv| "#{to_kebab_case(nk)}=#{nv}" }.join(",")
+            "--#{key}=#{nested}"
+          else
+            "--#{key}=#{v}"
           end
-          if body.has_key? "warnings"
-            warnings = body["warnings"].map {|warn| "\n  * #{warn}"}.join
-            UI.important "Sending the build to Bugsnag succeeded with the following warnings:#{warnings}\n\nPlease update your lane config."
-          end
+        end.join(" ")
+      end
+
+      def self.send_notification(cli_path, body)
+        args = self.json_to_cli_args(body)
+        bugsnag_cli_command = "#{cli_path} create-build #{args}"
+
+        UI.verbose("Running command: #{bugsnag_cli_command}")
+        success = Kernel.system(bugsnag_cli_command)
+        if success
+          UI.success("Build successfully sent to Bugsnag")
+        else
+          UI.user_error!("Failed to send build to Bugsnag.")
         end
       end
     end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -1,31 +1,13 @@
 require "xmlsimple"
 require "json"
 require_relative "find_info_plist_path"
-require_relative "bundled_cli_path"
+require_relative "bugsnag_cli"
 
 module Fastlane
   module Actions
     class SendBuildToBugsnagAction < Action
-      def self.get_bugsnag_cli_path(params)
-        bundled_bugsnag_cli_path = BundledCli.get_path
-        bundled_bugsnag_cli_version = Gem::Version.new(`#{bundled_bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
-
-        if params[:bugsnag_cli_path]
-          bugsnag_cli_path = params[:bugsnag_cli_path] || bundled_bugsnag_cli_path
-
-          bugsnag_cli_version = Gem::Version.new(`#{bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
-
-          if bugsnag_cli_version < bundled_bugsnag_cli_version
-            UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
-          end
-          bugsnag_cli_path
-        else
-          bundled_bugsnag_cli_path
-        end
-      end
-
       def self.run(params)
-        bugsnag_cli_path = get_bugsnag_cli_path(params)
+        bugsnag_cli_path = BugsnagCli.get_bugsnag_cli_path(params)
         UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
 
         payload = {}

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/send_build_to_bugsnag.rb
@@ -55,9 +55,7 @@ module Fastlane
           timeout,
           endpoint
         )
-        bugsnag_cli_command = "#{bugsnag_cli_path} create-build #{args.join(' ')}"
-        UI.verbose("Running command: #{bugsnag_cli_command}")
-        success = Kernel.system(bugsnag_cli_command)
+        success = BugsnagCli.create_build bugsnag_cli_path, args
         if success
           UI.success("Build successfully sent to Bugsnag")
         else

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -1,30 +1,12 @@
 require_relative "find_info_plist_path"
-require_relative "bundled_cli_path"
+require_relative "bugsnag_cli"
 
 
 module Fastlane
   module Actions
     class UploadSymbolsToBugsnagAction < Action
-      def self.get_bugsnag_cli_path(params)
-        bundled_bugsnag_cli_path = BundledCli.get_path
-        bundled_bugsnag_cli_version = Gem::Version.new(`#{bundled_bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
-
-        if params[:bugsnag_cli_path]
-          bugsnag_cli_path = params[:bugsnag_cli_path] || bundled_bugsnag_cli_path
-
-          bugsnag_cli_version = Gem::Version.new(`#{bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
-
-          if bugsnag_cli_version < bundled_bugsnag_cli_version
-            UI.warning("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
-          end
-          bugsnag_cli_path
-        else
-          bundled_bugsnag_cli_path
-        end
-      end
-
       def self.run(params)
-        bugsnag_cli_path = get_bugsnag_cli_path(params)
+        bugsnag_cli_path = BugsnagCli.get_bugsnag_cli_path(params)
         UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
 
         # If we have not explicitly set an API key through env, or parameter

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -10,7 +10,7 @@ module Fastlane
         UI.verbose("Using bugsnag-cli from path: #{bugsnag_cli_path}")
 
         # If we have not explicitly set an API key through env, or parameter
-        # input in Fastfile, find an API key in the Info.plist in config_file param
+        # input in Fastfile, find an API key from the Info.plist in config_file param
         api_key = params[:api_key]
         if params[:config_file] && params[:api_key] == nil
           UI.message("Using the API Key from #{params[:config_file]}")
@@ -46,9 +46,7 @@ module Fastlane
               params[:config_file],
               params[:xcode_project]
             )
-            bugsnag_cli_command = "#{bugsnag_cli_path} upload dsym #{args.join(' ')}"
-            UI.verbose("Running command: #{bugsnag_cli_command}")
-            success = Kernel.system(bugsnag_cli_command)
+            success = BugsnagCli.upload_dsym bugsnag_cli_path, args
             if success
               UI.success("Uploaded dSYMs in #{dsym_path}")
             else

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -1,13 +1,12 @@
 require_relative "find_info_plist_path"
-require 'os'
-require 'rbconfig'
+require_relative "bundled_cli_path"
 
 
 module Fastlane
   module Actions
     class UploadSymbolsToBugsnagAction < Action
       def self.get_bugsnag_cli_path(params)
-        bundled_bugsnag_cli_path = self.bundled_bugsnag_cli_path
+        bundled_bugsnag_cli_path = BundledCli.get_path
         bundled_bugsnag_cli_version = Gem::Version.new(`#{bundled_bugsnag_cli_path} --version`.scan(/(?:\d+\.?){3}/).first)
 
         if params[:bugsnag_cli_path]
@@ -290,36 +289,6 @@ module Fastlane
         paths += coerce_array(Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH]) if gym_dsyms?                     # set by `gym` Fastlane action
         paths += coerce_array(Actions.lane_context[SharedValues::DSYM_PATHS]) if download_dsym_dsyms?                 # set by `download_dsyms` Fastlane action
         parse_dsym_paths(paths.uniq)
-      end
-
-      def self.bundled_bugsnag_cli_path
-        host_cpu = RbConfig::CONFIG['host_cpu']
-        if OS.mac?
-          if host_cpu =~ /arm|aarch64/
-            self.bin_folder('arm64-macos-bugsnag-cli')
-          else
-            self.bin_folder('x86_64-macos-bugsnag-cli')
-          end
-        elsif OS.windows?
-          if OS.bits == 64
-            self.bin_folder('x86_64-windows-bugsnag-cli.exe')
-          else
-            self.bin_folder('i386-windows-bugsnag-cli.exe')
-          end
-        else
-          if host_cpu =~ /arm|aarch64/
-            self.bin_folder('arm64-linux-bugsnag-cli')
-          else if OS.bits == 64
-            self.bin_folder('x86_64-linux-bugsnag-cli')
-          else
-            self.bin_folder('i386-linux-bugsnag-cli')
-            end
-        end
-        end
-        end
-
-      def self.bin_folder(filename)
-        File.expand_path("../../../../../bin/#{filename}", File.dirname(__FILE__))
       end
     end
   end

--- a/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
+++ b/tools/fastlane-plugin/lib/fastlane/plugin/bugsnag/actions/upload_symbols_to_bugsnag.rb
@@ -19,7 +19,7 @@ module Fastlane
 
         # If verbose flag is enabled (`--verbose`), display the plugin action debug info
         # Store the verbose flag for use in the upload arguments.
-        verbose = UI.verbose("Uploading dSYMs to Bugsnag with the following parameters:")
+        UI.verbose("Uploading dSYMs to Bugsnag with the following parameters:")
         rjust = 30 # set justification width for keys for the list of parameters to output
         params.values.each do |param|
           UI.verbose("  #{param[0].to_s.rjust(rjust)}: #{param[1]}")
@@ -29,12 +29,11 @@ module Fastlane
 
         parse_dsym_paths(params[:dsym_path]).each do |dsym_path|
           if dsym_path.end_with?(".zip") or File.directory?(dsym_path)
-            args = upload_args(
+            args = BugsnagCli.upload_args(
               "\"#{dsym_path}\"",
               params[:upload_url],
               params[:project_root],
               api_key,
-              verbose,
               params[:ignore_missing_dwarf],
               params[:ignore_empty_dsym],
               params[:dryrun],
@@ -212,26 +211,7 @@ module Fastlane
         }
       end
 
-      def self.upload_args dir, upload_url, project_root, api_key, verbose, ignore_missing_dwarf, ignore_empty_dsym, dryrun, log_level, port, retries, timeout, configuration, scheme, plist, xcode_project
-        args = []
-        args += ["--verbose"] if verbose
-        args += ["--ignore-missing-dwarf"] if ignore_missing_dwarf
-        args += ["--ignore-empty-dsym"] if ignore_empty_dsym
-        args += ["--api-key", api_key] unless api_key.nil?
-        args += ["--upload-api-root-url", upload_url] unless upload_url.nil?
-        args += ["--project-root", project_root] unless project_root.nil?
-        args += ["--dry-run"] if dryrun
-        args += ["--log-level", log_level] unless log_level.nil?
-        args += ["--port", port] unless port.nil?
-        args += ["--retries", retries] unless retries.nil?
-        args += ["--timeout", timeout] unless timeout.nil?
-        args += ["--configuration", configuration] unless configuration.nil?
-        args += ["--scheme", scheme] unless scheme.nil?
-        args += ["--plist", plist] unless plist.nil?
-        args += ["--xcode-project", xcode_project] unless xcode_project.nil?
-        args << dir
-        args
-      end
+
 
       # returns an array of unique dSYM-containing directory paths to upload
       def self.parse_dsym_paths dsym_path

--- a/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
+++ b/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
+require_relative '../lib/fastlane/plugin/bugsnag/actions/bundled_cli_path'
 
 Action = Fastlane::Actions::UploadSymbolsToBugsnagAction
-BUGSNAG_CLI_PATH = Action::bundled_bugsnag_cli_path
+BUGSNAG_CLI_PATH = BundledCli.get_path
 
 describe Action do
   def run_with args

--- a/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
+++ b/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
@@ -167,7 +167,7 @@ describe Action do
       allow(Fastlane::Actions::UploadSymbolsToBugsnagAction).to receive(:version_from_cli).and_return("1.0.0")
       allow(Fastlane::Actions::UploadSymbolsToBugsnagAction).to receive(:bundled_bugsnag_cli_version).and_return(bundled_bugsnag_cli_version)
 
-      expect(Fastlane::UI).to receive(:warning).with("Your bugsnag-cli is outdated. The current bugsnag-cli version is: #{bundled_bugsnag_cli_version}")
+      expect(Fastlane::UI).to receive(:warning).with("The installed bugsnag-cli at #{cli_path} is outdated (1.0.0). The current bundled version is: #{bundled_bugsnag_cli_version}. It is recommended that you either update your installed version or use the bundled version.")
       expect(Kernel).to receive(:system).with("#{cli_path} upload dsym --project-root #{Dir::pwd} \"#{FIXTURE_PATH}\"").and_return(true)
 
       run_with({dsym_path: FIXTURE_PATH, bugsnag_cli_path: cli_path})

--- a/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
+++ b/tools/fastlane-plugin/spec/bugsnag_upload_dsym_action_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require_relative '../lib/fastlane/plugin/bugsnag/actions/bundled_cli_path'
+require_relative '../lib/fastlane/plugin/bugsnag/actions/bugsnag_cli'
 
 Action = Fastlane::Actions::UploadSymbolsToBugsnagAction
-BUGSNAG_CLI_PATH = BundledCli.get_path
+BUGSNAG_CLI_PATH = BugsnagCli.get_bundled_path
 
 describe Action do
   def run_with args

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 require 'json'
 require 'fastlane/actions/get_info_plist_value'
-require_relative '../lib/fastlane/plugin/bugsnag/actions/bundled_cli_path'
+require_relative '../lib/fastlane/plugin/bugsnag/actions/bugsnag_cli'
 
 
 BuildAction = Fastlane::Actions::SendBuildToBugsnagAction
-BUGSNAG_CLI_PATH = BundledCli.get_path
+BUGSNAG_CLI_PATH = BugsnagCli.get_bundled_path
 
 
 describe BuildAction do

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -6,6 +6,8 @@ require_relative '../lib/fastlane/plugin/bugsnag/actions/bugsnag_cli'
 
 BuildAction = Fastlane::Actions::SendBuildToBugsnagAction
 BUGSNAG_CLI_PATH = BugsnagCli.get_bundled_path
+GIT_REVISION = `git rev-parse HEAD`.strip
+BUILDER = `whoami`.strip
 
 
 describe BuildAction do
@@ -15,7 +17,7 @@ describe BuildAction do
 
   context 'building an iOS project' do
     it 'detects default Info.plist file excluding test dirs' do
-      expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789AAA --version-name 2.0-other --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+      expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789AAA --version-name 2.0-other --bundle-version 22 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
       Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
         run_with({})
       end
@@ -24,7 +26,7 @@ describe BuildAction do
     it 'reads api key from legacy location' do
       # the API key is now in `bugsnag.apiKey`, it used to be in 'BugsnagAPIKey',
       # test this can be extracted correctly from the `ios_proj_legacy`
-      expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789BBB --version-name 4.0-project --bundle-version 44 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+      expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789BBB --version-name 4.0-project --bundle-version 44 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
       Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj_legacy')) do
         run_with({})
       end
@@ -33,7 +35,7 @@ describe BuildAction do
     context 'using default config_file option' do
       context 'override API key from config' do
         it 'reads API key from the api_key option' do
-          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789FFF --version-name 2.0-other --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789FFF --version-name 2.0-other --bundle-version 22 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               api_key: '12345678901234567890123456789FFF'
@@ -42,7 +44,7 @@ describe BuildAction do
         end
 
         it 'uses input versions from options' do
-          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789AAA --version-name 8.0.0 --bundle-version 800 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789AAA --version-name 8.0.0 --bundle-version 800 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               app_version: '8.0.0',
@@ -55,7 +57,7 @@ describe BuildAction do
 
     context 'override config_file option' do
       it 'reads API key and version info from the config file' do
-        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 3.0-project --bundle-version 33 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 3.0-project --bundle-version 33 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
             config_file: File.join('Project', 'Info.plist')
@@ -65,7 +67,7 @@ describe BuildAction do
 
       context 'override API key, and config file' do
         it 'uses the input api_key to override a non default config' do
-          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789EEE --version-name 3.0-project --bundle-version 33 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789EEE --version-name 3.0-project --bundle-version 33 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               config_file: File.join('Project', 'Info.plist'),
@@ -75,7 +77,7 @@ describe BuildAction do
         end
 
         it 'uses the input versions to override a non default config' do
-          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 9.0.0 --bundle-version 900 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 9.0.0 --bundle-version 900 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               config_file: File.join('Project', 'Info.plist'),
@@ -89,7 +91,7 @@ describe BuildAction do
 
     context 'metadata added to args' do
       it "single key:value pair added" do
-        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git --metadata \"test1\": \"First test\"").and_return(true)
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload --metadata \"test1\": \"First test\"").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
             app_version: '4.0-project',
@@ -100,7 +102,7 @@ describe BuildAction do
       end
 
       it "multiple key:value pairs added" do
-        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git --metadata \"test1\": \"First test\", \"test2\": \"Second test\", \"test3\": \"Third test\"").and_return(true)
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload --metadata \"test1\": \"First test\", \"test2\": \"Second test\", \"test3\": \"Third test\"").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
                      app_version: '4.0-project',
@@ -111,7 +113,7 @@ describe BuildAction do
       end
 
       it "multiple key:value pairs added as a hash" do
-        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git --metadata \"custom_field_1\"=\"value1\", \"custom_field_2\"=\"value2\"").and_return(true)
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name #{BUILDER} --revision #{GIT_REVISION} --repository https://github.com/bugsnag/bugsnag-dsym-upload --metadata \"custom_field_1\"=\"value1\",\"custom_field_2\"=\"value2\"").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
                      app_version: '4.0-project',

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -16,10 +16,10 @@ describe BuildAction do
   context 'building an iOS project' do
     it 'detects default Info.plist file excluding test dirs' do
       expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-        payload = ::JSON.load(body)
-        expect(payload['versionName']).to eq '2.0-other'
-        expect(payload['bundleVersion']).to eq '22'
-        expect(payload['apiKey']).to eq '12345678901234567890123456789AAA'
+        args = ::JSON.load(body)
+        expect(args['versionName']).to eq '2.0-other'
+        expect(args['bundleVersion']).to eq '22'
+        expect(args['apiKey']).to eq '12345678901234567890123456789AAA'
       end
 
       Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -30,11 +30,11 @@ describe BuildAction do
     it 'reads api key from legacy location' do
       # the API key is now in `bugsnag.apiKey`, it used to be in 'BugsnagAPIKey',
       # test this can be extracted correctly from the `ios_proj_legacy`
-      expect(BuildAction).to receive(:send_notification) do |url, body|
-        payload = ::JSON.load(body)
-        expect(payload['versionName']).to eq '4.0-project'
-        expect(payload['bundleVersion']).to eq '44'
-        expect(payload['apiKey']).to eq '12345678901234567890123456789BBB'
+      expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+        args = ::JSON.load(body)
+        expect(args['versionName']).to eq '4.0-project'
+        expect(args['bundleVersion']).to eq '44'
+        expect(args['apiKey']).to eq '12345678901234567890123456789BBB'
       end
 
       Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj_legacy')) do
@@ -45,9 +45,9 @@ describe BuildAction do
     context 'using default config_file option' do
       context 'override API key from config' do
         it 'reads API key from the api_key option' do
-          expect(BuildAction).to receive(:send_notification) do |url, body|
-            payload = ::JSON.load(body)
-            expect(payload['apiKey']).to eq '12345678901234567890123456789FFF'
+          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+            args = ::JSON.load(body)
+            expect(args['apiKey']).to eq '12345678901234567890123456789FFF'
           end
 
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -58,10 +58,10 @@ describe BuildAction do
         end
 
         it 'uses input versions from options' do
-          expect(BuildAction).to receive(:send_notification) do |url, body|
-            payload = ::JSON.load(body)
-            expect(payload['versionName']).to eq '8.0.0'
-            expect(payload['bundleVersion']).to eq '800'
+          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+            args = ::JSON.load(body)
+            expect(args['versionName']).to eq '8.0.0'
+            expect(args['bundleVersion']).to eq '800'
           end
 
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -76,11 +76,11 @@ describe BuildAction do
 
     context 'override config_file option' do
       it 'reads API key and version info from the config file' do
-        expect(BuildAction).to receive(:send_notification) do |url, body|
-          payload = ::JSON.load(body)
-          expect(payload['versionName']).to eq '3.0-project'
-          expect(payload['bundleVersion']).to eq '33'
-          expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
+        expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+          args = ::JSON.load(body)
+          expect(args['versionName']).to eq '3.0-project'
+          expect(args['bundleVersion']).to eq '33'
+          expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
         end
 
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -92,11 +92,11 @@ describe BuildAction do
 
       context 'override API key, and config file' do
         it 'uses the input api_key to override a non default config' do
-          expect(BuildAction).to receive(:send_notification) do |url, body|
-            payload = ::JSON.load(body)
-            expect(payload['versionName']).to eq '3.0-project'
-            expect(payload['bundleVersion']).to eq '33'
-            expect(payload['apiKey']).to eq '12345678901234567890123456789EEE'
+          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+            args = ::JSON.load(body)
+            expect(args['versionName']).to eq '3.0-project'
+            expect(args['bundleVersion']).to eq '33'
+            expect(args['apiKey']).to eq '12345678901234567890123456789EEE'
           end
 
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -108,11 +108,11 @@ describe BuildAction do
         end
 
         it 'uses the input versions to override a non default config' do
-          expect(BuildAction).to receive(:send_notification) do |url, body|
-            payload = ::JSON.load(body)
-            expect(payload['versionName']).to eq '9.0.0'
-            expect(payload['bundleVersion']).to eq '900'
-            expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
+          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+            args = ::JSON.load(body)
+            expect(args['versionName']).to eq '9.0.0'
+            expect(args['bundleVersion']).to eq '900'
+            expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
           end
 
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -126,13 +126,13 @@ describe BuildAction do
       end
     end
 
-    context 'metadata added to payload' do
+    context 'metadata added to args' do
       it "single key:value pair added" do
-        expect(BuildAction).to receive(:send_notification) do |url, body|
-          payload = ::JSON.load(body)
-          expect(payload['versionName']).to eq '4.0-project'
-          expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
-          expect(payload['metadata']).to eq '"test1": "First test"'
+        expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+          args = ::JSON.load(body)
+          expect(args['versionName']).to eq '4.0-project'
+          expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
+          expect(args['metadata']).to eq '"test1": "First test"'
         end
 
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -145,11 +145,11 @@ describe BuildAction do
       end
 
       it "multiple key:value pairs added" do
-        expect(BuildAction).to receive(:send_notification) do |url, body|
-          payload = ::JSON.load(body)
-          expect(payload['versionName']).to eq '4.0-project'
-          expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
-          expect(payload['metadata']).to eq '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+        expect(BuildAction).to receive(:send_notification) do |cli_path, body|
+          args = ::JSON.load(body)
+          expect(args['versionName']).to eq '4.0-project'
+          expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
+          expect(args['metadata']).to eq '"test1": "First test", "test2": "Second test", "test3": "Third test"'
         end
 
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -15,13 +15,7 @@ describe BuildAction do
 
   context 'building an iOS project' do
     it 'detects default Info.plist file excluding test dirs' do
-      expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-        args = ::JSON.load(body)
-        expect(args['versionName']).to eq '2.0-other'
-        expect(args['bundleVersion']).to eq '22'
-        expect(args['apiKey']).to eq '12345678901234567890123456789AAA'
-      end
-
+      expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789AAA --version-name 2.0-other --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
       Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
         run_with({})
       end
@@ -30,13 +24,7 @@ describe BuildAction do
     it 'reads api key from legacy location' do
       # the API key is now in `bugsnag.apiKey`, it used to be in 'BugsnagAPIKey',
       # test this can be extracted correctly from the `ios_proj_legacy`
-      expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-        args = ::JSON.load(body)
-        expect(args['versionName']).to eq '4.0-project'
-        expect(args['bundleVersion']).to eq '44'
-        expect(args['apiKey']).to eq '12345678901234567890123456789BBB'
-      end
-
+      expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789BBB --version-name 4.0-project --bundle-version 44 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
       Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj_legacy')) do
         run_with({})
       end
@@ -45,11 +33,7 @@ describe BuildAction do
     context 'using default config_file option' do
       context 'override API key from config' do
         it 'reads API key from the api_key option' do
-          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-            args = ::JSON.load(body)
-            expect(args['apiKey']).to eq '12345678901234567890123456789FFF'
-          end
-
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789FFF --version-name 2.0-other --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               api_key: '12345678901234567890123456789FFF'
@@ -58,12 +42,7 @@ describe BuildAction do
         end
 
         it 'uses input versions from options' do
-          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-            args = ::JSON.load(body)
-            expect(args['versionName']).to eq '8.0.0'
-            expect(args['bundleVersion']).to eq '800'
-          end
-
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789AAA --version-name 8.0.0 --bundle-version 800 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               app_version: '8.0.0',
@@ -76,13 +55,7 @@ describe BuildAction do
 
     context 'override config_file option' do
       it 'reads API key and version info from the config file' do
-        expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-          args = ::JSON.load(body)
-          expect(args['versionName']).to eq '3.0-project'
-          expect(args['bundleVersion']).to eq '33'
-          expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
-        end
-
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 3.0-project --bundle-version 33 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
             config_file: File.join('Project', 'Info.plist')
@@ -92,13 +65,7 @@ describe BuildAction do
 
       context 'override API key, and config file' do
         it 'uses the input api_key to override a non default config' do
-          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-            args = ::JSON.load(body)
-            expect(args['versionName']).to eq '3.0-project'
-            expect(args['bundleVersion']).to eq '33'
-            expect(args['apiKey']).to eq '12345678901234567890123456789EEE'
-          end
-
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789EEE --version-name 3.0-project --bundle-version 33 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               config_file: File.join('Project', 'Info.plist'),
@@ -108,13 +75,7 @@ describe BuildAction do
         end
 
         it 'uses the input versions to override a non default config' do
-          expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-            args = ::JSON.load(body)
-            expect(args['versionName']).to eq '9.0.0'
-            expect(args['bundleVersion']).to eq '900'
-            expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
-          end
-
+          expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 9.0.0 --bundle-version 900 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git").and_return(true)
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
             run_with({
               config_file: File.join('Project', 'Info.plist'),
@@ -128,13 +89,7 @@ describe BuildAction do
 
     context 'metadata added to args' do
       it "single key:value pair added" do
-        expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-          args = ::JSON.load(body)
-          expect(args['versionName']).to eq '4.0-project'
-          expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
-          expect(args['metadata']).to eq '"test1": "First test"'
-        end
-
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git --metadata \"test1\": \"First test\"").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
             app_version: '4.0-project',
@@ -145,19 +100,27 @@ describe BuildAction do
       end
 
       it "multiple key:value pairs added" do
-        expect(BuildAction).to receive(:send_notification) do |cli_path, body|
-          args = ::JSON.load(body)
-          expect(args['versionName']).to eq '4.0-project'
-          expect(args['apiKey']).to eq '12345678901234567890123456789DDD'
-          expect(args['metadata']).to eq '"test1": "First test", "test2": "Second test", "test3": "Third test"'
-        end
-
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git --metadata \"test1\": \"First test\", \"test2\": \"Second test\", \"test3\": \"Third test\"").and_return(true)
         Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
           run_with({
-            app_version: '4.0-project',
-            api_key: '12345678901234567890123456789DDD',
-            metadata: '"test1": "First test", "test2": "Second test", "test3": "Third test"'
-          })
+                     app_version: '4.0-project',
+                     api_key: '12345678901234567890123456789DDD',
+                     metadata: '"test1": "First test", "test2": "Second test", "test3": "Third test"'
+                   })
+        end
+      end
+
+      it "multiple key:value pairs added as a hash" do
+        expect(Kernel).to receive(:system).with("#{BUGSNAG_CLI_PATH} create-build --api-key 12345678901234567890123456789DDD --version-name 4.0-project --bundle-version 22 --builder-name josh.edney --revision 3a30a510ba898341ff8631da49dc7021fb28c40e --repository git@github.com:bugsnag/bugsnag-dsym-upload.git --metadata \"custom_field_1\"=\"value1\", \"custom_field_2\"=\"value2\"").and_return(true)
+        Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
+          run_with({
+                     app_version: '4.0-project',
+                     api_key: '12345678901234567890123456789DDD',
+                     metadata: {
+                       "custom_field_1": "value1",
+                       "custom_field_2": "value2"
+                     }
+                   })
         end
       end
     end

--- a/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
+++ b/tools/fastlane-plugin/spec/send_build_to_bugsnag_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 require 'json'
 require 'fastlane/actions/get_info_plist_value'
+require_relative '../lib/fastlane/plugin/bugsnag/actions/bundled_cli_path'
+
 
 BuildAction = Fastlane::Actions::SendBuildToBugsnagAction
+BUGSNAG_CLI_PATH = BundledCli.get_path
+
 
 describe BuildAction do
   def run_with args
@@ -11,10 +15,10 @@ describe BuildAction do
 
   context 'building an iOS project' do
     it 'detects default Info.plist file excluding test dirs' do
-      expect(BuildAction).to receive(:send_notification) do |url, body|
+      expect(BuildAction).to receive(:send_notification) do |cli_path, body|
         payload = ::JSON.load(body)
-        expect(payload['appVersion']).to eq '2.0-other'
-        expect(payload['appBundleVersion']).to eq '22'
+        expect(payload['versionName']).to eq '2.0-other'
+        expect(payload['bundleVersion']).to eq '22'
         expect(payload['apiKey']).to eq '12345678901234567890123456789AAA'
       end
 
@@ -28,8 +32,8 @@ describe BuildAction do
       # test this can be extracted correctly from the `ios_proj_legacy`
       expect(BuildAction).to receive(:send_notification) do |url, body|
         payload = ::JSON.load(body)
-        expect(payload['appVersion']).to eq '4.0-project'
-        expect(payload['appBundleVersion']).to eq '44'
+        expect(payload['versionName']).to eq '4.0-project'
+        expect(payload['bundleVersion']).to eq '44'
         expect(payload['apiKey']).to eq '12345678901234567890123456789BBB'
       end
 
@@ -56,8 +60,8 @@ describe BuildAction do
         it 'uses input versions from options' do
           expect(BuildAction).to receive(:send_notification) do |url, body|
             payload = ::JSON.load(body)
-            expect(payload['appVersion']).to eq '8.0.0'
-            expect(payload['appBundleVersion']).to eq '800'
+            expect(payload['versionName']).to eq '8.0.0'
+            expect(payload['bundleVersion']).to eq '800'
           end
 
           Dir.chdir(File.join(FIXTURE_PATH, 'ios_proj')) do
@@ -74,8 +78,8 @@ describe BuildAction do
       it 'reads API key and version info from the config file' do
         expect(BuildAction).to receive(:send_notification) do |url, body|
           payload = ::JSON.load(body)
-          expect(payload['appVersion']).to eq '3.0-project'
-          expect(payload['appBundleVersion']).to eq '33'
+          expect(payload['versionName']).to eq '3.0-project'
+          expect(payload['bundleVersion']).to eq '33'
           expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
         end
 
@@ -90,8 +94,8 @@ describe BuildAction do
         it 'uses the input api_key to override a non default config' do
           expect(BuildAction).to receive(:send_notification) do |url, body|
             payload = ::JSON.load(body)
-            expect(payload['appVersion']).to eq '3.0-project'
-            expect(payload['appBundleVersion']).to eq '33'
+            expect(payload['versionName']).to eq '3.0-project'
+            expect(payload['bundleVersion']).to eq '33'
             expect(payload['apiKey']).to eq '12345678901234567890123456789EEE'
           end
 
@@ -106,8 +110,8 @@ describe BuildAction do
         it 'uses the input versions to override a non default config' do
           expect(BuildAction).to receive(:send_notification) do |url, body|
             payload = ::JSON.load(body)
-            expect(payload['appVersion']).to eq '9.0.0'
-            expect(payload['appBundleVersion']).to eq '900'
+            expect(payload['versionName']).to eq '9.0.0'
+            expect(payload['bundleVersion']).to eq '900'
             expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
           end
 
@@ -126,7 +130,7 @@ describe BuildAction do
       it "single key:value pair added" do
         expect(BuildAction).to receive(:send_notification) do |url, body|
           payload = ::JSON.load(body)
-          expect(payload['appVersion']).to eq '4.0-project'
+          expect(payload['versionName']).to eq '4.0-project'
           expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
           expect(payload['metadata']).to eq '"test1": "First test"'
         end
@@ -139,11 +143,11 @@ describe BuildAction do
           })
         end
       end
-      
+
       it "multiple key:value pairs added" do
         expect(BuildAction).to receive(:send_notification) do |url, body|
           payload = ::JSON.load(body)
-          expect(payload['appVersion']).to eq '4.0-project'
+          expect(payload['versionName']).to eq '4.0-project'
           expect(payload['apiKey']).to eq '12345678901234567890123456789DDD'
           expect(payload['metadata']).to eq '"test1": "First test", "test2": "Second test", "test3": "Third test"'
         end

--- a/tools/fastlane-plugin/spec/spec_helper.rb
+++ b/tools/fastlane-plugin/spec/spec_helper.rb
@@ -8,3 +8,11 @@ require 'fastlane' # to import the Action super class
 require 'fastlane/plugin/bugsnag' # import the actual plugin
 
 FIXTURE_PATH = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
+
+
+# expands the `got` and `expected` output in the RSpec output
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.max_formatted_output_length = nil # unlimited
+  end
+end


### PR DESCRIPTION
## Goal

Migrate to the Bugsnag CLI to send build information to the Bugsnag API.

## Testing

Covered by CI - Tests updated